### PR TITLE
Fixed paths on Windows builds for 4.x and 5.x branches

### DIFF
--- a/.github/workflows/OCV-Contrib-PR-3.4-ARM64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-3.4-ARM64.yaml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - '.github/workflows/OCV-Contrib-PR-3.4-ARM64.yaml'
   workflow_call:
 
 env:
@@ -35,8 +37,8 @@ jobs:
         - /home/opencv-cn/dnn-models:/home/ci/dnn-models
     steps:
     - name: Setup infra environment
-      if: ${{ github.event.repository.name != 'opencv-gha-workflow' }}
-      run: if [[ ${{ github.event.repository.name }} == 'ci-gha-workflow' ]]; then echo "TARGET_BRANCH_NAME=4.x" >> $GITHUB_ENV; fi
+      if: ${{ github.event.repository.name == 'ci-gha-workflow' }}
+      run: echo "TARGET_BRANCH_NAME=3.4" >> $GITHUB_ENV
     - name: PR info
       run: |
         echo "PR Author: ${{ env.PR_AUTHOR }}"

--- a/.github/workflows/OCV-Contrib-PR-3.4-U20.yaml
+++ b/.github/workflows/OCV-Contrib-PR-3.4-U20.yaml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - '.github/workflows/OCV-Contrib-PR-3.4-ARM64.yaml'
   workflow_call:
 
 env:
@@ -35,8 +37,8 @@ jobs:
         - /home/opencv-cn/dnn-models:/home/ci/dnn-models
     steps:
     - name: Setup infra environment
-      if: ${{ github.event.repository.name != 'opencv-gha-workflow' }}
-      run: if [[ ${{ github.event.repository.name }} == 'ci-gha-workflow' ]]; then echo "TARGET_BRANCH_NAME=3.4" >> $GITHUB_ENV; fi
+      if: ${{ github.event.repository.name == 'ci-gha-workflow' }}
+      run: echo "TARGET_BRANCH_NAME=3.4" >> $GITHUB_ENV
     - name: PR info
       run: |
         echo "PR Author: ${{ env.PR_AUTHOR }}"

--- a/.github/workflows/OCV-Contrib-PR-3.4-W10.yaml
+++ b/.github/workflows/OCV-Contrib-PR-3.4-W10.yaml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - '.github/workflows/OCV-Contrib-PR-3.4-W10.yaml'
   workflow_call:
 
 env:
@@ -23,9 +25,9 @@ jobs:
         shell: cmd
     steps:
     - name: Setup infra environment
-      if: ${{ github.event.repository.name != 'opencv-gha-workflow' }}
+      if: ${{ github.event.repository.name == 'ci-gha-workflow' }}
       shell: bash
-      run: if [[ ${{ github.event.repository.name }} == 'ci-gha-workflow' ]]; then echo "TARGET_BRANCH_NAME=3.4" >> $GITHUB_ENV; fi
+      run: echo "TARGET_BRANCH_NAME=3.4" >> $GITHUB_ENV
     - name: PR info
       run: |
         echo "PR Author: ${{ env.PR_AUTHOR }}"

--- a/.github/workflows/OCV-Contrib-PR-4.x-ARM64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-4.x-ARM64.yaml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - '.github/workflows/OCV-Contrib-PR-4.x-ARM64.yaml'
   workflow_call:
 
 env:
@@ -35,8 +37,8 @@ jobs:
         - /home/opencv-cn/dnn-models:/home/ci/dnn-models
     steps:
     - name: Setup infra environment
-      if: ${{ github.event.repository.name != 'opencv-gha-workflow' }}
-      run: if [[ ${{ github.event.repository.name }} == 'ci-gha-workflow' ]]; then echo "TARGET_BRANCH_NAME=4.x" >> $GITHUB_ENV; fi
+      if: ${{ github.event.repository.name == 'ci-gha-workflow' }}
+      run: echo "TARGET_BRANCH_NAME=4.x" >> $GITHUB_ENV
     - name: PR info
       run: |
         echo "PR Author: ${{ env.PR_AUTHOR }}"

--- a/.github/workflows/OCV-Contrib-PR-4.x-U20.yaml
+++ b/.github/workflows/OCV-Contrib-PR-4.x-U20.yaml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - '.github/workflows/OCV-Contrib-PR-4.x-U20.yaml'
   workflow_call:
 
 env:
@@ -35,8 +37,8 @@ jobs:
         - /home/opencv-cn/dnn-models:/home/ci/dnn-models
     steps:
     - name: Setup infra environment
-      if: ${{ github.event.repository.name != 'opencv-gha-workflow' }}
-      run: if [[ ${{ github.event.repository.name }} == 'ci-gha-workflow' ]]; then echo "TARGET_BRANCH_NAME=4.x" >> $GITHUB_ENV; fi
+      if: ${{ github.event.repository.name == 'ci-gha-workflow' }}
+      run: echo "TARGET_BRANCH_NAME=4.x" >> $GITHUB_ENV
     - name: PR info
       run: |
         echo "PR Author: ${{ env.PR_AUTHOR }}"

--- a/.github/workflows/OCV-Contrib-PR-4.x-W10.yaml
+++ b/.github/workflows/OCV-Contrib-PR-4.x-W10.yaml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - '.github/workflows/OCV-Contrib-PR-4.x-W10.yaml'
   workflow_call:
 
 env:
@@ -23,9 +25,9 @@ jobs:
         shell: cmd
     steps:
     - name: Setup infra environment
-      if: ${{ github.event.repository.name != 'opencv-gha-workflow' }}
+      if: ${{ github.event.repository.name == 'ci-gha-workflow' }}
       shell: bash
-      run: if [[ ${{ github.event.repository.name }} == 'ci-gha-workflow' ]]; then echo "TARGET_BRANCH_NAME=4.x" >> $GITHUB_ENV; fi
+      run: echo "TARGET_BRANCH_NAME=4.x" >> $GITHUB_ENV
     - name: PR info
       run: |
         echo "PR Author: ${{ env.PR_AUTHOR }}"

--- a/.github/workflows/OCV-Contrib-PR-5.x-ARM64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-5.x-ARM64.yaml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - '.github/workflows/OCV-Contrib-PR-5.x-ARM64.yaml'
   workflow_call:
 
 env:
@@ -35,8 +37,8 @@ jobs:
         - /home/opencv-cn/dnn-models:/home/ci/dnn-models
     steps:
     - name: Setup infra environment
-      if: ${{ github.event.repository.name != 'opencv-gha-workflow' }}
-      run: if [[ ${{ github.event.repository.name }} == 'ci-gha-workflow' ]]; then echo "TARGET_BRANCH_NAME=5.x" >> $GITHUB_ENV; fi
+      if: ${{ github.event.repository.name == 'ci-gha-workflow' }}
+      run: echo "TARGET_BRANCH_NAME=5.x" >> $GITHUB_ENV
     - name: PR info
       run: |
         echo "PR Author: ${{ env.PR_AUTHOR }}"

--- a/.github/workflows/OCV-Contrib-PR-5.x-U20.yaml
+++ b/.github/workflows/OCV-Contrib-PR-5.x-U20.yaml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - '.github/workflows/OCV-Contrib-PR-5.x-U20.yaml'
   workflow_call:
 
 env:
@@ -35,8 +37,8 @@ jobs:
         - /home/opencv-cn/dnn-models:/home/ci/dnn-models
     steps:
     - name: Setup infra environment
-      if: ${{ github.event.repository.name != 'opencv-gha-workflow' }}
-      run: if [[ ${{ github.event.repository.name }} == 'ci-gha-workflow' ]]; then echo "TARGET_BRANCH_NAME=5.x" >> $GITHUB_ENV; fi
+      if: ${{ github.event.repository.name == 'ci-gha-workflow' }}
+      run: echo "TARGET_BRANCH_NAME=5.x" >> $GITHUB_ENV
     - name: PR info
       run: |
         echo "PR Author: ${{ env.PR_AUTHOR }}"

--- a/.github/workflows/OCV-Contrib-PR-5.x-W10.yaml
+++ b/.github/workflows/OCV-Contrib-PR-5.x-W10.yaml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - '.github/workflows/OCV-Contrib-PR-5.x-W10.yaml'
   workflow_call:
 
 env:
@@ -23,9 +25,9 @@ jobs:
         shell: cmd
     steps:
     - name: Setup infra environment
-      if: ${{ github.event.repository.name != 'opencv-gha-workflow' }}
+      if: ${{ github.event.repository.name == 'ci-gha-workflow' }}
       shell: bash
-      run: if [[ ${{ github.event.repository.name }} == 'ci-gha-workflow' ]]; then echo "TARGET_BRANCH_NAME=5.x" >> $GITHUB_ENV; fi
+      run: echo "TARGET_BRANCH_NAME=5.x" >> $GITHUB_ENV
     - name: PR info
       run: |
         echo "PR Author: ${{ env.PR_AUTHOR }}"

--- a/.github/workflows/OCV-PR-3.4-ARM64.yaml
+++ b/.github/workflows/OCV-PR-3.4-ARM64.yaml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - '.github/workflows/OCV-PR-3.4-ARM64.yaml'
   workflow_call:
 
 env:
@@ -34,8 +36,8 @@ jobs:
         - /home/opencv-cn/dnn-models:/home/ci/dnn-models
     steps:
     - name: Setup infra environment
-      if: ${{ github.event.repository.name != 'opencv-gha-workflow' }}
-      run: if [[ ${{ github.event.repository.name }} == 'ci-gha-workflow' ]]; then echo "TARGET_BRANCH_NAME=3.4" >> $GITHUB_ENV; fi
+      if: ${{ github.event.repository.name == 'ci-gha-workflow' }}
+      run: echo "TARGET_BRANCH_NAME=3.4" >> $GITHUB_ENV
     - name: PR info
       run: |
         echo "PR Author: ${{ env.PR_AUTHOR }}"
@@ -176,8 +178,8 @@ jobs:
         - /home/opencv-cn/binaries_cache:/home/ci/binaries_cache
     steps:
     - name: Setup infra environment
-      if: ${{ github.event.repository.name != 'opencv-gha-workflow' }}
-      run: if [[ ${{ github.event.repository.name }} == 'ci-gha-workflow' ]]; then echo "TARGET_BRANCH_NAME=3.4" >> $GITHUB_ENV; fi
+      if: ${{ github.event.repository.name == 'ci-gha-workflow' }}
+      run: echo "TARGET_BRANCH_NAME=3.4" >> $GITHUB_ENV
     - name: PR info
       run: |
         echo "PR Author: ${{ env.PR_AUTHOR }}"

--- a/.github/workflows/OCV-PR-3.4-U20.yaml
+++ b/.github/workflows/OCV-PR-3.4-U20.yaml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - '.github/workflows/OCV-PR-3.4-U20.yaml'
   workflow_call:
 
 env:
@@ -34,8 +36,8 @@ jobs:
         - /home/opencv-cn/dnn-models:/home/ci/dnn-models
     steps:
     - name: Setup infra environment
-      if: ${{ github.event.repository.name != 'opencv-gha-workflow' }}
-      run: if [[ ${{ github.event.repository.name }} == 'ci-gha-workflow' ]]; then echo "TARGET_BRANCH_NAME=3.4" >> $GITHUB_ENV; fi
+      if: ${{ github.event.repository.name == 'ci-gha-workflow' }}
+      run: echo "TARGET_BRANCH_NAME=3.4" >> $GITHUB_ENV
     - name: PR info
       run: |
         echo "PR Author: ${{ env.PR_AUTHOR }}"
@@ -179,8 +181,8 @@ jobs:
         - /home/opencv-cn/binaries_cache:/home/ci/binaries_cache
     steps:
     - name: Setup infra environment
-      if: ${{ github.event.repository.name != 'opencv-gha-workflow' }}
-      run: if [[ ${{ github.event.repository.name }} == 'ci-gha-workflow' ]]; then echo "TARGET_BRANCH_NAME=3.4" >> $GITHUB_ENV; fi
+      if: ${{ github.event.repository.name == 'ci-gha-workflow' }}
+      run: echo "TARGET_BRANCH_NAME=3.4" >> $GITHUB_ENV
     - name: PR info
       run: |
         echo "PR Author: ${{ env.PR_AUTHOR }}"

--- a/.github/workflows/OCV-PR-3.4-W10.yaml
+++ b/.github/workflows/OCV-PR-3.4-W10.yaml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - '.github/workflows/OCV-PR-3.4-W10.yaml'
   workflow_call:
 
 env:
@@ -23,9 +25,9 @@ jobs:
         shell: cmd
     steps:
     - name: Setup infra environment
-      if: ${{ github.event.repository.name != 'opencv-gha-workflow' }}
+      if: ${{ github.event.repository.name == 'ci-gha-workflow' }}
       shell: bash
-      run: if [[ ${{ github.event.repository.name }} == 'ci-gha-workflow' ]]; then echo "TARGET_BRANCH_NAME=3.4" >> $GITHUB_ENV; fi
+      run: echo "TARGET_BRANCH_NAME=3.4" >> $GITHUB_ENV
     - name: PR info
       run: |
         echo "PR Author: ${{ env.PR_AUTHOR }}"
@@ -138,6 +140,7 @@ jobs:
         cd ${{ github.workspace }}\build
         set PATH=%PATH%;${{ github.workspace }}\build\bin
         ${{ github.workspace }}\opencv\modules\ts\misc\run.py . -a -t java
+
   BuildContrib:
     runs-on: opencv-cn-win
     defaults:
@@ -145,9 +148,9 @@ jobs:
         shell: cmd
     steps:
     - name: Setup infra environment
-      if: ${{ github.event.repository.name != 'opencv-gha-workflow' }}
+      if: ${{ github.event.repository.name == 'ci-gha-workflow' }}
       shell: bash
-      run: if [[ ${{ github.event.repository.name }} == 'ci-gha-workflow' ]]; then echo "TARGET_BRANCH_NAME=3.4" >> $GITHUB_ENV; fi
+      run: echo "TARGET_BRANCH_NAME=3.4" >> $GITHUB_ENV
     - name: PR info
       run: |
         echo "PR Author: ${{ env.PR_AUTHOR }}"

--- a/.github/workflows/OCV-PR-4.x-ARM64.yaml
+++ b/.github/workflows/OCV-PR-4.x-ARM64.yaml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - '.github/workflows/OCV-PR-4.x-ARM64.yaml'
   workflow_call:
 
 env:
@@ -34,8 +36,8 @@ jobs:
         - /home/opencv-cn/dnn-models:/home/ci/dnn-models
     steps:
     - name: Setup infra environment
-      if: ${{ github.event.repository.name != 'opencv-gha-workflow' }}
-      run: if [[ ${{ github.event.repository.name }} == 'ci-gha-workflow' ]]; then echo "TARGET_BRANCH_NAME=4.x" >> $GITHUB_ENV; fi
+      if: ${{ github.event.repository.name == 'ci-gha-workflow' }}
+      run: echo "TARGET_BRANCH_NAME=4.x" >> $GITHUB_ENV
     - name: PR info
       run: |
         echo "PR Author: ${{ env.PR_AUTHOR }}"
@@ -168,8 +170,8 @@ jobs:
         - /home/opencv-cn/binaries_cache:/home/ci/binaries_cache
     steps:
     - name: Setup infra environment
-      if: ${{ github.event.repository.name != 'opencv-gha-workflow' }}
-      run: if [[ ${{ github.event.repository.name }} == 'ci-gha-workflow' ]]; then echo "TARGET_BRANCH_NAME=4.x" >> $GITHUB_ENV; fi
+      if: ${{ github.event.repository.name == 'ci-gha-workflow' }}
+      run: echo "TARGET_BRANCH_NAME=4.x" >> $GITHUB_ENV
     - name: PR info
       run: |
         echo "PR Author: ${{ env.PR_AUTHOR }}"

--- a/.github/workflows/OCV-PR-4.x-U20.yaml
+++ b/.github/workflows/OCV-PR-4.x-U20.yaml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - '.github/workflows/OCV-PR-4.x-U20.yaml'
   workflow_call:
 
 env:
@@ -34,8 +36,8 @@ jobs:
         - /home/opencv-cn/dnn-models:/home/ci/dnn-models
     steps:
     - name: Setup infra environment
-      if: ${{ github.event.repository.name != 'opencv-gha-workflow' }}
-      run: if [[ ${{ github.event.repository.name }} == 'ci-gha-workflow' ]]; then echo "TARGET_BRANCH_NAME=4.x" >> $GITHUB_ENV; fi
+      if: ${{ github.event.repository.name == 'ci-gha-workflow' }}
+      run: echo "TARGET_BRANCH_NAME=4.x" >> $GITHUB_ENV
     - name: PR info
       run: |
         echo "PR Author: ${{ env.PR_AUTHOR }}"
@@ -175,8 +177,8 @@ jobs:
         - /home/opencv-cn/binaries_cache:/home/ci/binaries_cache
     steps:
     - name: Setup infra environment
-      if: ${{ github.event.repository.name != 'opencv-gha-workflow' }}
-      run: if [[ ${{ github.event.repository.name }} == 'ci-gha-workflow' ]]; then echo "TARGET_BRANCH_NAME=4.x" >> $GITHUB_ENV; fi
+      if: ${{ github.event.repository.name == 'ci-gha-workflow' }}
+      run: echo "TARGET_BRANCH_NAME=4.x" >> $GITHUB_ENV
     - name: PR info
       run: |
         echo "PR Author: ${{ env.PR_AUTHOR }}"

--- a/.github/workflows/OCV-PR-4.x-W10.yaml
+++ b/.github/workflows/OCV-PR-4.x-W10.yaml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - '.github/workflows/OCV-PR-4.x-W10.yaml'
   workflow_call:
 
 env:
@@ -23,9 +25,9 @@ jobs:
         shell: cmd
     steps:
     - name: Setup infra environment
-      if: ${{ github.event.repository.name != 'opencv-gha-workflow' }}
+      if: ${{ github.event.repository.name == 'ci-gha-workflow' }}
       shell: bash
-      run: if [[ ${{ github.event.repository.name }} == 'ci-gha-workflow' ]]; then echo "TARGET_BRANCH_NAME=4.x" >> $GITHUB_ENV; fi
+      run: echo "TARGET_BRANCH_NAME=4.x" >> $GITHUB_ENV
     - name: PR info
       run: |
         echo "PR Author: ${{ env.PR_AUTHOR }}"
@@ -134,6 +136,7 @@ jobs:
         cd ${{ github.workspace }}\build
         set PATH=%PATH%;${{ github.workspace }}\build\bin
         ${{ github.workspace }}\opencv\modules\ts\misc\run.py . -a -t java
+
   BuildContrib:
     runs-on: opencv-cn-win
     defaults:
@@ -141,9 +144,9 @@ jobs:
         shell: cmd
     steps:
     - name: Setup infra environment
-      if: ${{ github.event.repository.name != 'opencv-gha-workflow' }}
+      if: ${{ github.event.repository.name == 'ci-gha-workflow' }}
       shell: bash
-      run: if [[ ${{ github.event.repository.name }} == 'ci-gha-workflow' ]]; then echo "TARGET_BRANCH_NAME=4.x" >> $GITHUB_ENV; fi
+      run: echo "TARGET_BRANCH_NAME=4.x" >> $GITHUB_ENV
     - name: PR info
       run: |
         echo "PR Author: ${{ env.PR_AUTHOR }}"
@@ -170,7 +173,7 @@ jobs:
         OPENCV_CONTRIB_FORK=$(git ls-remote --heads "git@github.com:${{ env.PR_AUTHOR }}/opencv_contrib" "${{ env.SOURCE_BRANCH_NAME }}") || true
         if [[ ! -z "$OPENCV_CONTRIB_FORK" ]]; then
           echo "Merge opencv_contrib with ${{ env.SOURCE_BRANCH_NAME }} branch"
-          cd /opencv_contrib
+          cd opencv_contrib
           git config user.email "opencv.ci"
           git config user.name "opencv.ci"
           git pull -v "git@github.com:${{ env.PR_AUTHOR }}/opencv_contrib" "${{ env.SOURCE_BRANCH_NAME }}"

--- a/.github/workflows/OCV-PR-5.x-ARM64.yaml
+++ b/.github/workflows/OCV-PR-5.x-ARM64.yaml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - '.github/workflows/OCV-PR-5.x-ARM64.yaml'
   workflow_call:
 
 env:
@@ -34,8 +36,8 @@ jobs:
         - /home/opencv-cn/dnn-models:/home/ci/dnn-models
     steps:
     - name: Setup infra environment
-      if: ${{ github.event.repository.name != 'opencv-gha-workflow' }}
-      run: if [[ ${{ github.event.repository.name }} == 'ci-gha-workflow' ]]; then echo "TARGET_BRANCH_NAME=5.x" >> $GITHUB_ENV; fi
+      if: ${{ github.event.repository.name == 'ci-gha-workflow' }}
+      run: echo "TARGET_BRANCH_NAME=5.x" >> $GITHUB_ENV
     - name: PR info
       run: |
         echo "PR Author: ${{ env.PR_AUTHOR }}"
@@ -176,8 +178,8 @@ jobs:
         - /home/opencv-cn/binaries_cache:/home/ci/binaries_cache
     steps:
     - name: Setup infra environment
-      if: ${{ github.event.repository.name != 'opencv-gha-workflow' }}
-      run: if [[ ${{ github.event.repository.name }} == 'ci-gha-workflow' ]]; then echo "TARGET_BRANCH_NAME=5.x" >> $GITHUB_ENV; fi
+      if: ${{ github.event.repository.name == 'ci-gha-workflow' }}
+      run: echo "TARGET_BRANCH_NAME=5.x" >> $GITHUB_ENV
     - name: PR info
       run: |
         echo "PR Author: ${{ env.PR_AUTHOR }}"

--- a/.github/workflows/OCV-PR-5.x-U20.yaml
+++ b/.github/workflows/OCV-PR-5.x-U20.yaml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - '.github/workflows/OCV-PR-5.x-U20.yaml'
   workflow_call:
 
 env:
@@ -34,8 +36,8 @@ jobs:
         - /home/opencv-cn/dnn-models:/home/ci/dnn-models
     steps:
     - name: Setup infra environment
-      if: ${{ github.event.repository.name != 'opencv-gha-workflow' }}
-      run: if [[ ${{ github.event.repository.name }} == 'ci-gha-workflow' ]]; then echo "TARGET_BRANCH_NAME=5.x" >> $GITHUB_ENV; fi
+      if: ${{ github.event.repository.name == 'ci-gha-workflow' }}
+      run: echo "TARGET_BRANCH_NAME=5.x" >> $GITHUB_ENV
     - name: PR info
       run: |
         echo "PR Author: ${{ env.PR_AUTHOR }}"
@@ -183,8 +185,8 @@ jobs:
         - /home/opencv-cn/binaries_cache:/home/ci/binaries_cache
     steps:
     - name: Setup infra environment
-      if: ${{ github.event.repository.name != 'opencv-gha-workflow' }}
-      run: if [[ ${{ github.event.repository.name }} == 'ci-gha-workflow' ]]; then echo "TARGET_BRANCH_NAME=5.x" >> $GITHUB_ENV; fi
+      if: ${{ github.event.repository.name == 'ci-gha-workflow' }}
+      run: echo "TARGET_BRANCH_NAME=5.x" >> $GITHUB_ENV
     - name: PR info
       run: |
         echo "PR Author: ${{ env.PR_AUTHOR }}"

--- a/.github/workflows/OCV-PR-5.x-W10.yaml
+++ b/.github/workflows/OCV-PR-5.x-W10.yaml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - '.github/workflows/OCV-PR-5.x-W10.yaml'
   workflow_call:
 
 env:
@@ -23,9 +25,9 @@ jobs:
         shell: cmd
     steps:
     - name: Setup infra environment
-      if: ${{ github.event.repository.name != 'opencv-gha-workflow' }}
+      if: ${{ github.event.repository.name == 'ci-gha-workflow' }}
       shell: bash
-      run: if [[ ${{ github.event.repository.name }} == 'ci-gha-workflow' ]]; then echo "TARGET_BRANCH_NAME=5.x" >> $GITHUB_ENV; fi
+      run: echo "TARGET_BRANCH_NAME=5.x" >> $GITHUB_ENV
     - name: PR info
       run: |
         echo "PR Author: ${{ env.PR_AUTHOR }}"
@@ -142,6 +144,7 @@ jobs:
         cd ${{ github.workspace }}\build
         set PATH=%PATH%;${{ github.workspace }}\build\bin
         ${{ github.workspace }}\opencv\modules\ts\misc\run.py . -a -t java
+
   BuildContrib:
     runs-on: opencv-cn-win
     defaults:
@@ -149,9 +152,9 @@ jobs:
         shell: cmd
     steps:
     - name: Setup infra environment
-      if: ${{ github.event.repository.name != 'opencv-gha-workflow' }}
+      if: ${{ github.event.repository.name == 'ci-gha-workflow' }}
       shell: bash
-      run: if [[ ${{ github.event.repository.name }} == 'ci-gha-workflow' ]]; then echo "TARGET_BRANCH_NAME=5.x" >> $GITHUB_ENV; fi
+      run: echo "TARGET_BRANCH_NAME=5.x" >> $GITHUB_ENV
     - name: PR info
       run: |
         echo "PR Author: ${{ env.PR_AUTHOR }}"
@@ -178,7 +181,7 @@ jobs:
         OPENCV_CONTRIB_FORK=$(git ls-remote --heads "git@github.com:${{ env.PR_AUTHOR }}/opencv_contrib" "${{ env.SOURCE_BRANCH_NAME }}") || true
         if [[ ! -z "$OPENCV_CONTRIB_FORK" ]]; then
           echo "Merge opencv_contrib with ${{ env.SOURCE_BRANCH_NAME }} branch"
-          cd /opencv_contrib
+          cd opencv_contrib
           git config user.email "opencv.ci"
           git config user.name "opencv.ci"
           git pull -v "git@github.com:${{ env.PR_AUTHOR }}/opencv_contrib" "${{ env.SOURCE_BRANCH_NAME }}"

--- a/.github/workflows/OCV-timvx-backend-tests-4.x.yml
+++ b/.github/workflows/OCV-timvx-backend-tests-4.x.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - '.github/workflows/OCV-Contrib-PR-3.4-ARM64.yaml'
   workflow_call:
 
 env:
@@ -19,9 +21,9 @@ jobs:
     container: docker.io/yuentau/ocv_ubuntu:20.04
     steps:
       - name: Setup infra environment
-        if: ${{ github.event.repository.name != 'opencv-gha-workflow' }}
+        if: ${{ github.event.repository.name == 'ci-gha-workflow' }}
         shell: bash
-        run: if [[ ${{ github.event.repository.name }} == 'ci-gha-workflow' ]]; then echo "TARGET_BRANCH_NAME=4.x" >> $GITHUB_ENV; fi
+        run: echo "TARGET_BRANCH_NAME=4.x" >> $GITHUB_ENV
       - name: info
         run: |
           echo "PR Author: ${{ env.PR_AUTHOR }}"


### PR DESCRIPTION
It was fixed only for 3.4 branch in https://github.com/opencv/opencv/pull/21986 and https://github.com/opencv/opencv/pull/21998, updated for other branches also.

In addition, added `paths` to not to run workflows which weren't changed.

Fixed `if` condition to setup infra environment.