### PR TITLE
Fixed environment variable for scheduled job

### DIFF
--- a/.github/workflows/OCV-Android-SDK.yaml
+++ b/.github/workflows/OCV-Android-SDK.yaml
@@ -33,7 +33,7 @@ jobs:
         - /home/opencv-cn/ci_cache/opencv:/home/ci/.ccache
     steps:
     - name: Setup infra environment
-      if: ${{ github.event.repository.name == 'ci-gha-workflow' }}
+      if: ${{ github.event.repository.name == 'ci-gha-workflow' || github.event_name == 'schedule' }}
       run: echo "TARGET_BRANCH_NAME=4.x" >> $GITHUB_ENV
     - name: PR info
       run: |

--- a/.github/workflows/OCV-PR-3.4-iOS.yaml
+++ b/.github/workflows/OCV-PR-3.4-iOS.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: macOS-M1
     steps:
       - name: Setup infra environment
-        if: ${{ github.event.repository.name == 'ci-gha-workflow' }}
+        if: ${{ github.event.repository.name == 'ci-gha-workflow' || github.event_name == 'schedule' }}
         run: echo "TARGET_BRANCH_NAME=3.4" >> $GITHUB_ENV
       - name: PR info
         run: |

--- a/.github/workflows/OCV-PR-4.x-iOS.yaml
+++ b/.github/workflows/OCV-PR-4.x-iOS.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: macOS-M1
     steps:
       - name: Setup infra environment
-        if: ${{ github.event.repository.name == 'ci-gha-workflow' }}
+        if: ${{ github.event.repository.name == 'ci-gha-workflow' || github.event_name == 'schedule' }}
         run: echo "TARGET_BRANCH_NAME=4.x" >> $GITHUB_ENV
       - name: PR info
         run: |

--- a/.github/workflows/OCV-PR-5.x-iOS.yaml
+++ b/.github/workflows/OCV-PR-5.x-iOS.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: macOS-M1
     steps:
       - name: Setup infra environment
-        if: ${{ github.event.repository.name == 'ci-gha-workflow' }}
+        if: ${{ github.event.repository.name == 'ci-gha-workflow' || github.event_name == 'schedule' }}
         run: echo "TARGET_BRANCH_NAME=5.x" >> $GITHUB_ENV
       - name: PR info
         run: |


### PR DESCRIPTION
This is strange, but `github.event.repository.name` is unavailable when your workflow is triggered on schedule.

Failed job with a skipped setting up the environment variable: https://github.com/opencv/ci-gha-workflow/runs/6734573311?check_suite_focus=true