### PR TITLE
Print system information in the first step for workflows with self-hosted runners

### DIFF
--- a/.github/workflows/OCV-Contrib-PR-3.4-ARM64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-3.4-ARM64.yaml
@@ -36,6 +36,9 @@ jobs:
         - /home/opencv-cn/binaries_cache:/home/ci/binaries_cache
         - /home/opencv-cn/dnn-models:/home/ci/dnn-models
     steps:
+    - name: Brief system information
+      timeout-minutes: 60
+      run: bash ${{ env.GIT_CACHE_DOCKER }}/print_system_information.sh
     - name: Define proper HOME path
       timeout-minutes: 60
       run: echo "HOME=/root" >> $GITHUB_ENV

--- a/.github/workflows/OCV-Contrib-PR-3.4-U20.yaml
+++ b/.github/workflows/OCV-Contrib-PR-3.4-U20.yaml
@@ -36,6 +36,9 @@ jobs:
         - /home/opencv-cn/binaries_cache:/home/ci/binaries_cache
         - /home/opencv-cn/dnn-models:/home/ci/dnn-models
     steps:
+    - name: Brief system information
+      timeout-minutes: 60
+      run: bash ${{ env.GIT_CACHE_DOCKER }}/print_system_information.sh
     - name: Define proper HOME path
       timeout-minutes: 60
       run: echo "HOME=/root" >> $GITHUB_ENV

--- a/.github/workflows/OCV-Contrib-PR-3.4-W10.yaml
+++ b/.github/workflows/OCV-Contrib-PR-3.4-W10.yaml
@@ -25,6 +25,9 @@ jobs:
       run:
         shell: cmd
     steps:
+    - name: Brief system information
+      timeout-minutes: 60
+      run: bash ${{ env.GIT_CACHE_DOCKER }}\print_system_information.sh
     - name: Setup infra environment
       timeout-minutes: 60
       if: ${{ github.event.repository.name == 'ci-gha-workflow' }}

--- a/.github/workflows/OCV-Contrib-PR-3.4-W10.yaml
+++ b/.github/workflows/OCV-Contrib-PR-3.4-W10.yaml
@@ -27,7 +27,7 @@ jobs:
     steps:
     - name: Brief system information
       timeout-minutes: 60
-      run: bash ${{ env.GIT_CACHE_DOCKER }}\print_system_information.sh
+      run: bash %GIT_CACHE%\print_system_information.sh
     - name: Setup infra environment
       timeout-minutes: 60
       if: ${{ github.event.repository.name == 'ci-gha-workflow' }}

--- a/.github/workflows/OCV-Contrib-PR-3.4-macOS-ARM64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-3.4-macOS-ARM64.yaml
@@ -26,6 +26,9 @@ jobs:
       run:
         shell: bash
     steps:
+    - name: Brief system information
+      timeout-minutes: 60
+      run: bash $GIT_CACHE/print_system_information.sh
     - name: Setup infra environment
       timeout-minutes: 60
       if: ${{ github.event.repository.name == 'ci-gha-workflow' }}

--- a/.github/workflows/OCV-Contrib-PR-3.4-macOS-x86_64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-3.4-macOS-x86_64.yaml
@@ -26,6 +26,9 @@ jobs:
       run:
         shell: bash
     steps:
+    - name: Brief system information
+      timeout-minutes: 60
+      run: bash $GIT_CACHE/print_system_information.sh
     - name: Setup infra environment
       timeout-minutes: 60
       if: ${{ github.event.repository.name == 'ci-gha-workflow' }}

--- a/.github/workflows/OCV-Contrib-PR-4.x-ARM64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-4.x-ARM64.yaml
@@ -36,6 +36,9 @@ jobs:
         - /home/opencv-cn/binaries_cache:/home/ci/binaries_cache
         - /home/opencv-cn/dnn-models:/home/ci/dnn-models
     steps:
+    - name: Brief system information
+      timeout-minutes: 60
+      run: bash ${{ env.GIT_CACHE_DOCKER }}/print_system_information.sh
     - name: Define proper HOME path
       timeout-minutes: 60
       run: echo "HOME=/root" >> $GITHUB_ENV

--- a/.github/workflows/OCV-Contrib-PR-4.x-U20.yaml
+++ b/.github/workflows/OCV-Contrib-PR-4.x-U20.yaml
@@ -36,6 +36,9 @@ jobs:
         - /home/opencv-cn/binaries_cache:/home/ci/binaries_cache
         - /home/opencv-cn/dnn-models:/home/ci/dnn-models
     steps:
+    - name: Brief system information
+      timeout-minutes: 60
+      run: bash ${{ env.GIT_CACHE_DOCKER }}/print_system_information.sh
     - name: Define proper HOME path
       timeout-minutes: 60
       run: echo "HOME=/root" >> $GITHUB_ENV

--- a/.github/workflows/OCV-Contrib-PR-4.x-W10.yaml
+++ b/.github/workflows/OCV-Contrib-PR-4.x-W10.yaml
@@ -25,6 +25,9 @@ jobs:
       run:
         shell: cmd
     steps:
+    - name: Brief system information
+      timeout-minutes: 60
+      run: bash ${{ env.GIT_CACHE_DOCKER }}\print_system_information.sh
     - name: Setup infra environment
       timeout-minutes: 60
       if: ${{ github.event.repository.name == 'ci-gha-workflow' }}

--- a/.github/workflows/OCV-Contrib-PR-4.x-W10.yaml
+++ b/.github/workflows/OCV-Contrib-PR-4.x-W10.yaml
@@ -27,7 +27,7 @@ jobs:
     steps:
     - name: Brief system information
       timeout-minutes: 60
-      run: bash ${{ env.GIT_CACHE_DOCKER }}\print_system_information.sh
+      run: bash %GIT_CACHE%\print_system_information.sh
     - name: Setup infra environment
       timeout-minutes: 60
       if: ${{ github.event.repository.name == 'ci-gha-workflow' }}

--- a/.github/workflows/OCV-Contrib-PR-4.x-macOS-ARM64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-4.x-macOS-ARM64.yaml
@@ -26,6 +26,9 @@ jobs:
       run:
         shell: bash
     steps:
+    - name: Brief system information
+      timeout-minutes: 60
+      run: bash $GIT_CACHE/print_system_information.sh
     - name: Setup infra environment
       timeout-minutes: 60
       if: ${{ github.event.repository.name == 'ci-gha-workflow' }}

--- a/.github/workflows/OCV-Contrib-PR-4.x-macOS-x86_64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-4.x-macOS-x86_64.yaml
@@ -26,6 +26,9 @@ jobs:
       run:
         shell: bash
     steps:
+    - name: Brief system information
+      timeout-minutes: 60
+      run: bash $GIT_CACHE/print_system_information.sh
     - name: Setup infra environment
       timeout-minutes: 60
       if: ${{ github.event.repository.name == 'ci-gha-workflow' }}

--- a/.github/workflows/OCV-Contrib-PR-5.x-ARM64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-5.x-ARM64.yaml
@@ -36,6 +36,9 @@ jobs:
         - /home/opencv-cn/binaries_cache:/home/ci/binaries_cache
         - /home/opencv-cn/dnn-models:/home/ci/dnn-models
     steps:
+    - name: Brief system information
+      timeout-minutes: 60
+      run: bash ${{ env.GIT_CACHE_DOCKER }}/print_system_information.sh
     - name: Define proper HOME path
       timeout-minutes: 60
       run: echo "HOME=/root" >> $GITHUB_ENV

--- a/.github/workflows/OCV-Contrib-PR-5.x-U20.yaml
+++ b/.github/workflows/OCV-Contrib-PR-5.x-U20.yaml
@@ -36,6 +36,9 @@ jobs:
         - /home/opencv-cn/binaries_cache:/home/ci/binaries_cache
         - /home/opencv-cn/dnn-models:/home/ci/dnn-models
     steps:
+    - name: Brief system information
+      timeout-minutes: 60
+      run: bash ${{ env.GIT_CACHE_DOCKER }}/print_system_information.sh
     - name: Define proper HOME path
       timeout-minutes: 60
       run: echo "HOME=/root" >> $GITHUB_ENV

--- a/.github/workflows/OCV-Contrib-PR-5.x-W10.yaml
+++ b/.github/workflows/OCV-Contrib-PR-5.x-W10.yaml
@@ -25,6 +25,9 @@ jobs:
       run:
         shell: cmd
     steps:
+    - name: Brief system information
+      timeout-minutes: 60
+      run: bash ${{ env.GIT_CACHE_DOCKER }}\print_system_information.sh
     - name: Setup infra environment
       timeout-minutes: 60
       if: ${{ github.event.repository.name == 'ci-gha-workflow' }}

--- a/.github/workflows/OCV-Contrib-PR-5.x-W10.yaml
+++ b/.github/workflows/OCV-Contrib-PR-5.x-W10.yaml
@@ -27,7 +27,7 @@ jobs:
     steps:
     - name: Brief system information
       timeout-minutes: 60
-      run: bash ${{ env.GIT_CACHE_DOCKER }}\print_system_information.sh
+      run: bash %GIT_CACHE%\print_system_information.sh
     - name: Setup infra environment
       timeout-minutes: 60
       if: ${{ github.event.repository.name == 'ci-gha-workflow' }}

--- a/.github/workflows/OCV-Contrib-PR-5.x-macOS-ARM64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-5.x-macOS-ARM64.yaml
@@ -26,6 +26,9 @@ jobs:
       run:
         shell: bash
     steps:
+    - name: Brief system information
+      timeout-minutes: 60
+      run: bash $GIT_CACHE/print_system_information.sh
     - name: Setup infra environment
       timeout-minutes: 60
       if: ${{ github.event.repository.name == 'ci-gha-workflow' }}

--- a/.github/workflows/OCV-Contrib-PR-5.x-macOS-x86_64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-5.x-macOS-x86_64.yaml
@@ -26,6 +26,9 @@ jobs:
       run:
         shell: bash
     steps:
+    - name: Brief system information
+      timeout-minutes: 60
+      run: bash $GIT_CACHE/print_system_information.sh
     - name: Setup infra environment
       timeout-minutes: 60
       if: ${{ github.event.repository.name == 'ci-gha-workflow' }}

--- a/.github/workflows/OCV-PR-3.4-ARM64.yaml
+++ b/.github/workflows/OCV-PR-3.4-ARM64.yaml
@@ -35,6 +35,9 @@ jobs:
         - /home/opencv-cn/binaries_cache:/home/ci/binaries_cache
         - /home/opencv-cn/dnn-models:/home/ci/dnn-models
     steps:
+    - name: Brief system information
+      timeout-minutes: 60
+      run: bash ${{ env.GIT_CACHE_DOCKER }}/print_system_information.sh
     - name: Define proper HOME path
       timeout-minutes: 60
       run: echo "HOME=/root" >> $GITHUB_ENV
@@ -250,6 +253,9 @@ jobs:
         - /home/opencv-cn/ci_cache/opencv:/home/ci/.ccache
         - /home/opencv-cn/binaries_cache:/home/ci/binaries_cache
     steps:
+    - name: Brief system information
+      timeout-minutes: 60
+      run: bash ${{ env.GIT_CACHE_DOCKER }}/print_system_information.sh
     - name: Define proper HOME path
       timeout-minutes: 60
       run: echo "HOME=/root" >> $GITHUB_ENV

--- a/.github/workflows/OCV-PR-3.4-U20.yaml
+++ b/.github/workflows/OCV-PR-3.4-U20.yaml
@@ -258,6 +258,9 @@ jobs:
         - /home/opencv-cn/ci_cache/opencv:/home/ci/.ccache
         - /home/opencv-cn/binaries_cache:/home/ci/binaries_cache
     steps:
+    - name: Brief system information
+      timeout-minutes: 60
+      run: bash ${{ env.GIT_CACHE_DOCKER }}/print_system_information.sh
     - name: Define proper HOME path
       timeout-minutes: 60
       run: echo "HOME=/root" >> $GITHUB_ENV

--- a/.github/workflows/OCV-PR-3.4-U20.yaml
+++ b/.github/workflows/OCV-PR-3.4-U20.yaml
@@ -35,6 +35,9 @@ jobs:
         - /home/opencv-cn/binaries_cache:/home/ci/binaries_cache
         - /home/opencv-cn/dnn-models:/home/ci/dnn-models
     steps:
+    - name: Brief system information
+      timeout-minutes: 60
+      run: bash ${{ env.GIT_CACHE_DOCKER }}/print_system_information.sh
     - name: Define proper HOME path
       timeout-minutes: 60
       run: echo "HOME=/root" >> $GITHUB_ENV

--- a/.github/workflows/OCV-PR-3.4-W10.yaml
+++ b/.github/workflows/OCV-PR-3.4-W10.yaml
@@ -25,6 +25,9 @@ jobs:
       run:
         shell: cmd
     steps:
+    - name: Brief system information
+      timeout-minutes: 60
+      run: bash ${{ env.GIT_CACHE_DOCKER }}\print_system_information.sh
     - name: Setup infra environment
       timeout-minutes: 60
       if: ${{ github.event.repository.name == 'ci-gha-workflow' }}

--- a/.github/workflows/OCV-PR-3.4-W10.yaml
+++ b/.github/workflows/OCV-PR-3.4-W10.yaml
@@ -27,7 +27,7 @@ jobs:
     steps:
     - name: Brief system information
       timeout-minutes: 60
-      run: bash ${{ env.GIT_CACHE_DOCKER }}\print_system_information.sh
+      run: bash %GIT_CACHE%\print_system_information.sh
     - name: Setup infra environment
       timeout-minutes: 60
       if: ${{ github.event.repository.name == 'ci-gha-workflow' }}

--- a/.github/workflows/OCV-PR-3.4-W10.yaml
+++ b/.github/workflows/OCV-PR-3.4-W10.yaml
@@ -250,6 +250,9 @@ jobs:
       run:
         shell: cmd
     steps:
+    - name: Brief system information
+      timeout-minutes: 60
+      run: bash %GIT_CACHE%\print_system_information.sh
     - name: Setup infra environment
       timeout-minutes: 60
       if: ${{ github.event.repository.name == 'ci-gha-workflow' }}

--- a/.github/workflows/OCV-PR-3.4-macOS-ARM64.yaml
+++ b/.github/workflows/OCV-PR-3.4-macOS-ARM64.yaml
@@ -26,6 +26,9 @@ jobs:
       run:
         shell: bash
     steps:
+    - name: Brief system information
+      timeout-minutes: 60
+      run: bash $GIT_CACHE/print_system_information.sh
     - name: Setup infra environment
       timeout-minutes: 60
       if: ${{ github.event.repository.name == 'ci-gha-workflow' }}
@@ -267,6 +270,9 @@ jobs:
       run:
         shell: bash
     steps:
+    - name: Brief system information
+      timeout-minutes: 60
+      run: bash $GIT_CACHE/print_system_information.sh
     - name: Setup infra environment
       timeout-minutes: 60
       if: ${{ github.event.repository.name == 'ci-gha-workflow' }}

--- a/.github/workflows/OCV-PR-3.4-macOS-x86_64.yaml
+++ b/.github/workflows/OCV-PR-3.4-macOS-x86_64.yaml
@@ -25,6 +25,9 @@ jobs:
       run:
         shell: bash
     steps:
+    - name: Brief system information
+      timeout-minutes: 60
+      run: bash $GIT_CACHE/print_system_information.sh
     - name: Setup infra environment
       timeout-minutes: 60
       if: ${{ github.event.repository.name == 'ci-gha-workflow' }}
@@ -267,6 +270,9 @@ jobs:
       run:
         shell: bash
     steps:
+    - name: Brief system information
+      timeout-minutes: 60
+      run: bash $GIT_CACHE/print_system_information.sh
     - name: Setup infra environment
       timeout-minutes: 60
       if: ${{ github.event.repository.name == 'ci-gha-workflow' }}

--- a/.github/workflows/OCV-PR-4.x-ARM64.yaml
+++ b/.github/workflows/OCV-PR-4.x-ARM64.yaml
@@ -35,6 +35,9 @@ jobs:
         - /home/opencv-cn/binaries_cache:/home/ci/binaries_cache
         - /home/opencv-cn/dnn-models:/home/ci/dnn-models
     steps:
+    - name: Brief system information
+      timeout-minutes: 60
+      run: bash ${{ env.GIT_CACHE_DOCKER }}/print_system_information.sh
     - name: Define proper HOME path
       timeout-minutes: 60
       run: echo "HOME=/root" >> $GITHUB_ENV
@@ -234,6 +237,9 @@ jobs:
         - /home/opencv-cn/ci_cache/opencv:/home/ci/.ccache
         - /home/opencv-cn/binaries_cache:/home/ci/binaries_cache
     steps:
+    - name: Brief system information
+      timeout-minutes: 60
+      run: bash ${{ env.GIT_CACHE_DOCKER }}/print_system_information.sh
     - name: Define proper HOME path
       timeout-minutes: 60
       run: echo "HOME=/root" >> $GITHUB_ENV

--- a/.github/workflows/OCV-PR-4.x-U20.yaml
+++ b/.github/workflows/OCV-PR-4.x-U20.yaml
@@ -36,6 +36,9 @@ jobs:
         - /home/opencv-cn/binaries_cache:/home/ci/binaries_cache
         - /home/opencv-cn/dnn-models:/home/ci/dnn-models
     steps:
+    - name: Brief system information
+      timeout-minutes: 60
+      run: bash ${{ env.GIT_CACHE_DOCKER }}/print_system_information.sh
     - name: Define proper HOME path
       timeout-minutes: 60
       run: echo "HOME=/root" >> $GITHUB_ENV

--- a/.github/workflows/OCV-PR-4.x-U20.yaml
+++ b/.github/workflows/OCV-PR-4.x-U20.yaml
@@ -251,6 +251,9 @@ jobs:
         - /home/opencv-cn/ci_cache/opencv:/home/ci/.ccache
         - /home/opencv-cn/binaries_cache:/home/ci/binaries_cache
     steps:
+    - name: Brief system information
+      timeout-minutes: 60
+      run: bash ${{ env.GIT_CACHE_DOCKER }}/print_system_information.sh
     - name: Define proper HOME path
       timeout-minutes: 60
       run: echo "HOME=/root" >> $GITHUB_ENV

--- a/.github/workflows/OCV-PR-4.x-W10.yaml
+++ b/.github/workflows/OCV-PR-4.x-W10.yaml
@@ -25,6 +25,9 @@ jobs:
       run:
         shell: cmd
     steps:
+    - name: Brief system information
+      timeout-minutes: 60
+      run: bash ${{ env.GIT_CACHE_DOCKER }}\print_system_information.sh
     - name: Setup infra environment
       timeout-minutes: 60
       if: ${{ github.event.repository.name == 'ci-gha-workflow' }}

--- a/.github/workflows/OCV-PR-4.x-W10.yaml
+++ b/.github/workflows/OCV-PR-4.x-W10.yaml
@@ -27,7 +27,7 @@ jobs:
     steps:
     - name: Brief system information
       timeout-minutes: 60
-      run: bash ${{ env.GIT_CACHE_DOCKER }}\print_system_information.sh
+      run: bash %GIT_CACHE%\print_system_information.sh
     - name: Setup infra environment
       timeout-minutes: 60
       if: ${{ github.event.repository.name == 'ci-gha-workflow' }}

--- a/.github/workflows/OCV-PR-4.x-W10.yaml
+++ b/.github/workflows/OCV-PR-4.x-W10.yaml
@@ -242,6 +242,9 @@ jobs:
       run:
         shell: cmd
     steps:
+    - name: Brief system information
+      timeout-minutes: 60
+      run: bash %GIT_CACHE%\print_system_information.sh
     - name: Setup infra environment
       timeout-minutes: 60
       if: ${{ github.event.repository.name == 'ci-gha-workflow' }}

--- a/.github/workflows/OCV-PR-4.x-macOS-ARM64.yaml
+++ b/.github/workflows/OCV-PR-4.x-macOS-ARM64.yaml
@@ -26,6 +26,9 @@ jobs:
       run:
         shell: bash
     steps:
+    - name: Brief system information
+      timeout-minutes: 60
+      run: bash $GIT_CACHE/print_system_information.sh
     - name: Setup infra environment
       timeout-minutes: 60
       if: ${{ github.event.repository.name == 'ci-gha-workflow' }}
@@ -256,6 +259,9 @@ jobs:
       run:
         shell: bash
     steps:
+    - name: Brief system information
+      timeout-minutes: 60
+      run: bash $GIT_CACHE/print_system_information.sh
     - name: Setup infra environment
       timeout-minutes: 60
       if: ${{ github.event.repository.name == 'ci-gha-workflow' }}

--- a/.github/workflows/OCV-PR-4.x-macOS-x86_64.yaml
+++ b/.github/workflows/OCV-PR-4.x-macOS-x86_64.yaml
@@ -25,6 +25,9 @@ jobs:
       run:
         shell: bash
     steps:
+    - name: Brief system information
+      timeout-minutes: 60
+      run: bash $GIT_CACHE/print_system_information.sh
     - name: Setup infra environment
       timeout-minutes: 60
       if: ${{ github.event.repository.name == 'ci-gha-workflow' }}
@@ -257,6 +260,9 @@ jobs:
       run:
         shell: bash
     steps:
+    - name: Brief system information
+      timeout-minutes: 60
+      run: bash $GIT_CACHE/print_system_information.sh
     - name: Setup infra environment
       timeout-minutes: 60
       if: ${{ github.event.repository.name == 'ci-gha-workflow' }}

--- a/.github/workflows/OCV-PR-5.x-ARM64.yaml
+++ b/.github/workflows/OCV-PR-5.x-ARM64.yaml
@@ -35,6 +35,9 @@ jobs:
         - /home/opencv-cn/binaries_cache:/home/ci/binaries_cache
         - /home/opencv-cn/dnn-models:/home/ci/dnn-models
     steps:
+    - name: Brief system information
+      timeout-minutes: 60
+      run: bash ${{ env.GIT_CACHE_DOCKER }}/print_system_information.sh
     - name: Define proper HOME path
       timeout-minutes: 60
       run: echo "HOME=/root" >> $GITHUB_ENV
@@ -250,6 +253,9 @@ jobs:
         - /home/opencv-cn/ci_cache/opencv:/home/ci/.ccache
         - /home/opencv-cn/binaries_cache:/home/ci/binaries_cache
     steps:
+    - name: Brief system information
+      timeout-minutes: 60
+      run: bash ${{ env.GIT_CACHE_DOCKER }}/print_system_information.sh
     - name: Define proper HOME path
       timeout-minutes: 60
       run: echo "HOME=/root" >> $GITHUB_ENV

--- a/.github/workflows/OCV-PR-5.x-U20.yaml
+++ b/.github/workflows/OCV-PR-5.x-U20.yaml
@@ -265,6 +265,9 @@ jobs:
         - /home/opencv-cn/ci_cache/opencv:/home/ci/.ccache
         - /home/opencv-cn/binaries_cache:/home/ci/binaries_cache
     steps:
+    - name: Brief system information
+      timeout-minutes: 60
+      run: bash ${{ env.GIT_CACHE_DOCKER }}/print_system_information.sh
     - name: Define proper HOME path
       timeout-minutes: 60
       run: echo "HOME=/root" >> $GITHUB_ENV

--- a/.github/workflows/OCV-PR-5.x-U20.yaml
+++ b/.github/workflows/OCV-PR-5.x-U20.yaml
@@ -35,6 +35,9 @@ jobs:
         - /home/opencv-cn/binaries_cache:/home/ci/binaries_cache
         - /home/opencv-cn/dnn-models:/home/ci/dnn-models
     steps:
+    - name: Brief system information
+      timeout-minutes: 60
+      run: bash ${{ env.GIT_CACHE_DOCKER }}/print_system_information.sh
     - name: Define proper HOME path
       timeout-minutes: 60
       run: echo "HOME=/root" >> $GITHUB_ENV

--- a/.github/workflows/OCV-PR-5.x-W10.yaml
+++ b/.github/workflows/OCV-PR-5.x-W10.yaml
@@ -25,6 +25,9 @@ jobs:
       run:
         shell: cmd
     steps:
+    - name: Brief system information
+      timeout-minutes: 60
+      run: bash ${{ env.GIT_CACHE_DOCKER }}\print_system_information.sh
     - name: Setup infra environment
       timeout-minutes: 60
       if: ${{ github.event.repository.name == 'ci-gha-workflow' }}

--- a/.github/workflows/OCV-PR-5.x-W10.yaml
+++ b/.github/workflows/OCV-PR-5.x-W10.yaml
@@ -27,7 +27,7 @@ jobs:
     steps:
     - name: Brief system information
       timeout-minutes: 60
-      run: bash ${{ env.GIT_CACHE_DOCKER }}\print_system_information.sh
+      run: bash %GIT_CACHE%\print_system_information.sh
     - name: Setup infra environment
       timeout-minutes: 60
       if: ${{ github.event.repository.name == 'ci-gha-workflow' }}

--- a/.github/workflows/OCV-PR-5.x-W10.yaml
+++ b/.github/workflows/OCV-PR-5.x-W10.yaml
@@ -258,6 +258,9 @@ jobs:
       run:
         shell: cmd
     steps:
+    - name: Brief system information
+      timeout-minutes: 60
+      run: bash %GIT_CACHE%\print_system_information.sh
     - name: Setup infra environment
       timeout-minutes: 60
       if: ${{ github.event.repository.name == 'ci-gha-workflow' }}

--- a/.github/workflows/OCV-PR-5.x-macOS-ARM64.yaml
+++ b/.github/workflows/OCV-PR-5.x-macOS-ARM64.yaml
@@ -26,6 +26,9 @@ jobs:
       run:
         shell: bash
     steps:
+    - name: Brief system information
+      timeout-minutes: 60
+      run: bash $GIT_CACHE/print_system_information.sh
     - name: Setup infra environment
       timeout-minutes: 60
       if: ${{ github.event.repository.name == 'ci-gha-workflow' }}
@@ -276,6 +279,9 @@ jobs:
       run:
         shell: bash
     steps:
+    - name: Brief system information
+      timeout-minutes: 60
+      run: bash $GIT_CACHE/print_system_information.sh
     - name: Setup infra environment
       timeout-minutes: 60
       if: ${{ github.event.repository.name == 'ci-gha-workflow' }}

--- a/.github/workflows/OCV-PR-5.x-macOS-x86_64.yaml
+++ b/.github/workflows/OCV-PR-5.x-macOS-x86_64.yaml
@@ -25,6 +25,9 @@ jobs:
       run:
         shell: bash
     steps:
+    - name: Brief system information
+      timeout-minutes: 60
+      run: bash $GIT_CACHE/print_system_information.sh
     - name: Setup infra environment
       timeout-minutes: 60
       if: ${{ github.event.repository.name == 'ci-gha-workflow' }}
@@ -277,6 +280,9 @@ jobs:
       run:
         shell: bash
     steps:
+    - name: Brief system information
+      timeout-minutes: 60
+      run: bash $GIT_CACHE/print_system_information.sh
     - name: Setup infra environment
       timeout-minutes: 60
       if: ${{ github.event.repository.name == 'ci-gha-workflow' }}


### PR DESCRIPTION
The script to print is put under the git_cache directory on each machine. We can put it in a new location in a new environment variable (lets call it `tools` or something else) but it requires GHA registered on every machine.

OpenCV wiki page on CI configuration is also updated: https://github.com/opencv/opencv/wiki/CI-configuration.

Progress:
- [x] Ubuntu20.04-X64
- [x] Windows10-X64
- [x] Ubuntu18.04-ARM64
- [x] macOS-ARM64
- [x] macOS-X64