### PR TITLE
Fix defining a path for a local variable on macOS

### DIFF
--- a/.github/workflows/OCV-Contrib-PR-3.4-macOS-ARM64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-3.4-macOS-ARM64.yaml
@@ -96,7 +96,7 @@ jobs:
           echo "OPENCV_DNN_TEST_DATA_PATH=$DNN_MODELS" >> $GITHUB_ENV
         else
           echo "Updating DNN models list"
-          echo "OPENCV_DNN_TEST_DATA_PATH=$OPENCV_CI_HOME/new-dnn-models" >> $GITHUB_ENV && OPENCV_DNN_TEST_DATA_PATH='$OPENCV_CI_HOME/new-dnn-models'
+          echo "OPENCV_DNN_TEST_DATA_PATH=${{ github.workspace }}/new-dnn-models" >> $GITHUB_ENV && OPENCV_DNN_TEST_DATA_PATH="${{ github.workspace }}/new-dnn-models"
           mkdir -p "$OPENCV_DNN_TEST_DATA_PATH"
           rsync -a --exclude=$DOWNLOAD_MODELS_FILE $DNN_MODELS/* $OPENCV_DNN_TEST_DATA_PATH
           cp opencv_extra/testdata/dnn/download_models.py $OPENCV_DNN_TEST_DATA_PATH/dnn

--- a/.github/workflows/OCV-Contrib-PR-3.4-macOS-x86_64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-3.4-macOS-x86_64.yaml
@@ -96,7 +96,7 @@ jobs:
           echo "OPENCV_DNN_TEST_DATA_PATH=$DNN_MODELS" >> $GITHUB_ENV
         else
           echo "Updating DNN models list"
-          echo "OPENCV_DNN_TEST_DATA_PATH=$OPENCV_CI_HOME/new-dnn-models" >> $GITHUB_ENV && OPENCV_DNN_TEST_DATA_PATH='$OPENCV_CI_HOME/new-dnn-models'
+          echo "OPENCV_DNN_TEST_DATA_PATH=${{ github.workspace }}/new-dnn-models" >> $GITHUB_ENV && OPENCV_DNN_TEST_DATA_PATH="${{ github.workspace }}/new-dnn-models"
           mkdir -p "$OPENCV_DNN_TEST_DATA_PATH"
           rsync -a --exclude=$DOWNLOAD_MODELS_FILE $DNN_MODELS/* $OPENCV_DNN_TEST_DATA_PATH
           cp opencv_extra/testdata/dnn/download_models.py $OPENCV_DNN_TEST_DATA_PATH/dnn

--- a/.github/workflows/OCV-Contrib-PR-4.x-macOS-ARM64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-4.x-macOS-ARM64.yaml
@@ -97,7 +97,7 @@ jobs:
           echo "OPENCV_DNN_TEST_DATA_PATH=$DNN_MODELS" >> $GITHUB_ENV
         else
           echo "Updating DNN models list"
-          echo "OPENCV_DNN_TEST_DATA_PATH=$OPENCV_CI_HOME/new-dnn-models" >> $GITHUB_ENV && OPENCV_DNN_TEST_DATA_PATH='$OPENCV_CI_HOME/new-dnn-models'
+          echo "OPENCV_DNN_TEST_DATA_PATH=${{ github.workspace }}/new-dnn-models" >> $GITHUB_ENV && OPENCV_DNN_TEST_DATA_PATH="${{ github.workspace }}/new-dnn-models"
           mkdir -p "$OPENCV_DNN_TEST_DATA_PATH"
           rsync -a --exclude=$DOWNLOAD_MODELS_FILE $DNN_MODELS/* $OPENCV_DNN_TEST_DATA_PATH
           cp opencv_extra/testdata/dnn/download_models.py $OPENCV_DNN_TEST_DATA_PATH/dnn

--- a/.github/workflows/OCV-Contrib-PR-4.x-macOS-x86_64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-4.x-macOS-x86_64.yaml
@@ -96,7 +96,7 @@ jobs:
           echo "OPENCV_DNN_TEST_DATA_PATH=$DNN_MODELS" >> $GITHUB_ENV
         else
           echo "Updating DNN models list"
-          echo "OPENCV_DNN_TEST_DATA_PATH=$OPENCV_CI_HOME/new-dnn-models" >> $GITHUB_ENV && OPENCV_DNN_TEST_DATA_PATH='$OPENCV_CI_HOME/new-dnn-models'
+          echo "OPENCV_DNN_TEST_DATA_PATH=${{ github.workspace }}/new-dnn-models" >> $GITHUB_ENV && OPENCV_DNN_TEST_DATA_PATH="${{ github.workspace }}/new-dnn-models"
           mkdir -p "$OPENCV_DNN_TEST_DATA_PATH"
           rsync -a --exclude=$DOWNLOAD_MODELS_FILE $DNN_MODELS/* $OPENCV_DNN_TEST_DATA_PATH
           cp opencv_extra/testdata/dnn/download_models.py $OPENCV_DNN_TEST_DATA_PATH/dnn

--- a/.github/workflows/OCV-Contrib-PR-5.x-macOS-ARM64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-5.x-macOS-ARM64.yaml
@@ -96,7 +96,7 @@ jobs:
           echo "OPENCV_DNN_TEST_DATA_PATH=$DNN_MODELS" >> $GITHUB_ENV
         else
           echo "Updating DNN models list"
-          echo "OPENCV_DNN_TEST_DATA_PATH=$OPENCV_CI_HOME/new-dnn-models" >> $GITHUB_ENV && OPENCV_DNN_TEST_DATA_PATH='$OPENCV_CI_HOME/new-dnn-models'
+          echo "OPENCV_DNN_TEST_DATA_PATH=${{ github.workspace }}/new-dnn-models" >> $GITHUB_ENV && OPENCV_DNN_TEST_DATA_PATH="${{ github.workspace }}/new-dnn-models"
           mkdir -p "$OPENCV_DNN_TEST_DATA_PATH"
           rsync -a --exclude=$DOWNLOAD_MODELS_FILE $DNN_MODELS/* $OPENCV_DNN_TEST_DATA_PATH
           cp opencv_extra/testdata/dnn/download_models.py $OPENCV_DNN_TEST_DATA_PATH/dnn

--- a/.github/workflows/OCV-Contrib-PR-5.x-macOS-x86_64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-5.x-macOS-x86_64.yaml
@@ -96,7 +96,7 @@ jobs:
           echo "OPENCV_DNN_TEST_DATA_PATH=$DNN_MODELS" >> $GITHUB_ENV
         else
           echo "Updating DNN models list"
-          echo "OPENCV_DNN_TEST_DATA_PATH=$OPENCV_CI_HOME/new-dnn-models" >> $GITHUB_ENV && OPENCV_DNN_TEST_DATA_PATH='$OPENCV_CI_HOME/new-dnn-models'
+          echo "OPENCV_DNN_TEST_DATA_PATH=${{ github.workspace }}/new-dnn-models" >> $GITHUB_ENV && OPENCV_DNN_TEST_DATA_PATH="${{ github.workspace }}/new-dnn-models"
           mkdir -p "$OPENCV_DNN_TEST_DATA_PATH"
           rsync -a --exclude=$DOWNLOAD_MODELS_FILE $DNN_MODELS/* $OPENCV_DNN_TEST_DATA_PATH
           cp opencv_extra/testdata/dnn/download_models.py $OPENCV_DNN_TEST_DATA_PATH/dnn

--- a/.github/workflows/OCV-PR-3.4-macOS-ARM64.yaml
+++ b/.github/workflows/OCV-PR-3.4-macOS-ARM64.yaml
@@ -80,7 +80,7 @@ jobs:
           echo "OPENCV_DNN_TEST_DATA_PATH=$DNN_MODELS" >> $GITHUB_ENV
         else
           echo "Updating DNN models list"
-          echo "OPENCV_DNN_TEST_DATA_PATH=$OPENCV_CI_HOME/new-dnn-models" >> $GITHUB_ENV && OPENCV_DNN_TEST_DATA_PATH='$OPENCV_CI_HOME/new-dnn-models'
+          echo "OPENCV_DNN_TEST_DATA_PATH=${{ github.workspace }}/new-dnn-models" >> $GITHUB_ENV && OPENCV_DNN_TEST_DATA_PATH="${{ github.workspace }}/new-dnn-models"
           mkdir -p "$OPENCV_DNN_TEST_DATA_PATH"
           rsync -a --exclude=$DOWNLOAD_MODELS_FILE $DNN_MODELS/* $OPENCV_DNN_TEST_DATA_PATH
           cp opencv_extra/testdata/dnn/download_models.py $OPENCV_DNN_TEST_DATA_PATH/dnn

--- a/.github/workflows/OCV-PR-3.4-macOS-x86_64.yaml
+++ b/.github/workflows/OCV-PR-3.4-macOS-x86_64.yaml
@@ -79,7 +79,7 @@ jobs:
           echo "OPENCV_DNN_TEST_DATA_PATH=$DNN_MODELS" >> $GITHUB_ENV
         else
           echo "Updating DNN models list"
-          echo "OPENCV_DNN_TEST_DATA_PATH=$OPENCV_CI_HOME/new-dnn-models" >> $GITHUB_ENV && OPENCV_DNN_TEST_DATA_PATH='$OPENCV_CI_HOME/new-dnn-models'
+          echo "OPENCV_DNN_TEST_DATA_PATH=${{ github.workspace }}/new-dnn-models" >> $GITHUB_ENV && OPENCV_DNN_TEST_DATA_PATH="${{ github.workspace }}/new-dnn-models"
           mkdir -p "$OPENCV_DNN_TEST_DATA_PATH"
           rsync -a --exclude=$DOWNLOAD_MODELS_FILE $DNN_MODELS/* $OPENCV_DNN_TEST_DATA_PATH
           cp opencv_extra/testdata/dnn/download_models.py $OPENCV_DNN_TEST_DATA_PATH/dnn

--- a/.github/workflows/OCV-PR-4.x-macOS-ARM64.yaml
+++ b/.github/workflows/OCV-PR-4.x-macOS-ARM64.yaml
@@ -80,7 +80,7 @@ jobs:
           echo "OPENCV_DNN_TEST_DATA_PATH=$DNN_MODELS" >> $GITHUB_ENV
         else
           echo "Updating DNN models list"
-          echo "OPENCV_DNN_TEST_DATA_PATH=$OPENCV_CI_HOME/new-dnn-models" >> $GITHUB_ENV && OPENCV_DNN_TEST_DATA_PATH='$OPENCV_CI_HOME/new-dnn-models'
+          echo "OPENCV_DNN_TEST_DATA_PATH=${{ github.workspace }}/new-dnn-models" >> $GITHUB_ENV && OPENCV_DNN_TEST_DATA_PATH="${{ github.workspace }}/new-dnn-models"
           mkdir -p "$OPENCV_DNN_TEST_DATA_PATH"
           rsync -a --exclude=$DOWNLOAD_MODELS_FILE $DNN_MODELS/* $OPENCV_DNN_TEST_DATA_PATH
           cp opencv_extra/testdata/dnn/download_models.py $OPENCV_DNN_TEST_DATA_PATH/dnn

--- a/.github/workflows/OCV-PR-4.x-macOS-x86_64.yaml
+++ b/.github/workflows/OCV-PR-4.x-macOS-x86_64.yaml
@@ -79,7 +79,7 @@ jobs:
           echo "OPENCV_DNN_TEST_DATA_PATH=$DNN_MODELS" >> $GITHUB_ENV
         else
           echo "Updating DNN models list"
-          echo "OPENCV_DNN_TEST_DATA_PATH=$OPENCV_CI_HOME/new-dnn-models" >> $GITHUB_ENV && OPENCV_DNN_TEST_DATA_PATH='$OPENCV_CI_HOME/new-dnn-models'
+          echo "OPENCV_DNN_TEST_DATA_PATH=${{ github.workspace }}/new-dnn-models" >> $GITHUB_ENV && OPENCV_DNN_TEST_DATA_PATH="${{ github.workspace }}/new-dnn-models"
           mkdir -p "$OPENCV_DNN_TEST_DATA_PATH"
           rsync -a --exclude=$DOWNLOAD_MODELS_FILE $DNN_MODELS/* $OPENCV_DNN_TEST_DATA_PATH
           cp opencv_extra/testdata/dnn/download_models.py $OPENCV_DNN_TEST_DATA_PATH/dnn

--- a/.github/workflows/OCV-PR-5.x-macOS-ARM64.yaml
+++ b/.github/workflows/OCV-PR-5.x-macOS-ARM64.yaml
@@ -80,7 +80,7 @@ jobs:
           echo "OPENCV_DNN_TEST_DATA_PATH=$DNN_MODELS" >> $GITHUB_ENV
         else
           echo "Updating DNN models list"
-          echo "OPENCV_DNN_TEST_DATA_PATH=$OPENCV_CI_HOME/new-dnn-models" >> $GITHUB_ENV && OPENCV_DNN_TEST_DATA_PATH='$OPENCV_CI_HOME/new-dnn-models'
+          echo "OPENCV_DNN_TEST_DATA_PATH=${{ github.workspace }}/new-dnn-models" >> $GITHUB_ENV && OPENCV_DNN_TEST_DATA_PATH="${{ github.workspace }}/new-dnn-models"
           mkdir -p "$OPENCV_DNN_TEST_DATA_PATH"
           rsync -a --exclude=$DOWNLOAD_MODELS_FILE $DNN_MODELS/* $OPENCV_DNN_TEST_DATA_PATH
           cp opencv_extra/testdata/dnn/download_models.py $OPENCV_DNN_TEST_DATA_PATH/dnn

--- a/.github/workflows/OCV-PR-5.x-macOS-x86_64.yaml
+++ b/.github/workflows/OCV-PR-5.x-macOS-x86_64.yaml
@@ -79,7 +79,7 @@ jobs:
           echo "OPENCV_DNN_TEST_DATA_PATH=$DNN_MODELS" >> $GITHUB_ENV
         else
           echo "Updating DNN models list"
-          echo "OPENCV_DNN_TEST_DATA_PATH=$OPENCV_CI_HOME/new-dnn-models" >> $GITHUB_ENV && OPENCV_DNN_TEST_DATA_PATH='$OPENCV_CI_HOME/new-dnn-models'
+          echo "OPENCV_DNN_TEST_DATA_PATH=${{ github.workspace }}/new-dnn-models" >> $GITHUB_ENV && OPENCV_DNN_TEST_DATA_PATH="${{ github.workspace }}/new-dnn-models"
           mkdir -p "$OPENCV_DNN_TEST_DATA_PATH"
           rsync -a --exclude=$DOWNLOAD_MODELS_FILE $DNN_MODELS/* $OPENCV_DNN_TEST_DATA_PATH
           cp opencv_extra/testdata/dnn/download_models.py $OPENCV_DNN_TEST_DATA_PATH/dnn


### PR DESCRIPTION
The previous state created a folder `$OPENCV_CI_HOME` and there was a wrong path to DNN models if it overrides with `$OPENCV_CI_HOME/new-dnn-models`.

- Workflow variable: `OPENCV_DNN_TEST_DATA_PATH=$OPENCV_CI_HOME/new-dnn-models` works properly with the full path
- Local variable: `OPENCV_DNN_TEST_DATA_PATH='$OPENCV_CI_HOME/new-dnn-models'` doesn't work properly in case of `''`