### PR TITLE
Draft: Turn off actions by GitHub and turn on disabled workflows

### DIFF
--- a/.github/workflows/OCV-Contrib-PR-3.4-ARM64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-3.4-ARM64.yaml
@@ -25,8 +25,6 @@ env:
 
 jobs:
   BuildAndTest:
-    # Temporarily disabled this job
-    if: ${{ github.event.repository.name == 'disabled' }}
     runs-on: opencv-cn-lin-arm64
     defaults:
       run:
@@ -372,10 +370,10 @@ jobs:
       id: java-test
       if: ${{ always() && steps.build-opencv-contrib.outcome == 'success' }}
       run: cd $HOME/build && xvfb-run -a python3 $HOME/opencv/modules/ts/misc/run.py . -a -t java
-    - name: Save Unit Test Results
-      timeout-minutes: 60
-      uses: actions/upload-artifact@v3
-      if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
-      with:
-        name: junit-html
-        path: /home/ci/build/java_test/testResults/junit-noframes.html
+    # - name: Save Unit Test Results
+    #   timeout-minutes: 60
+    #   uses: actions/upload-artifact@v3
+    #   if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
+    #   with:
+    #     name: junit-html
+    #     path: /home/ci/build/java_test/testResults/junit-noframes.html

--- a/.github/workflows/OCV-Contrib-PR-3.4-U14.yaml
+++ b/.github/workflows/OCV-Contrib-PR-3.4-U14.yaml
@@ -25,8 +25,6 @@ env:
 
 jobs:
   BuildAndTest:
-    # Temporarily disabled this job
-    if: ${{ github.event.repository.name == 'disabled' }}
     runs-on: opencv-cn-lin-x86-64
     defaults:
       run:
@@ -372,10 +370,10 @@ jobs:
       id: java-test
       if: ${{ always() && steps.build-opencv-contrib.outcome == 'success' }}
       run: cd $HOME/build && xvfb-run -a python3 $HOME/opencv/modules/ts/misc/run.py . -a -t java
-    - name: Save Unit Test Results
-      timeout-minutes: 60
-      uses: actions/upload-artifact@v3
-      if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
-      with:
-        name: junit-html
-        path: /home/ci/build/java_test/testResults/junit-noframes.html
+    # - name: Save Unit Test Results
+    #   timeout-minutes: 60
+    #   uses: actions/upload-artifact@v3
+    #   if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
+    #   with:
+    #     name: junit-html
+    #     path: /home/ci/build/java_test/testResults/junit-noframes.html

--- a/.github/workflows/OCV-Contrib-PR-3.4-U20.yaml
+++ b/.github/workflows/OCV-Contrib-PR-3.4-U20.yaml
@@ -25,8 +25,6 @@ env:
 
 jobs:
   BuildAndTest:
-    # Temporarily disabled this job
-    if: ${{ github.event.repository.name == 'disabled' }}
     runs-on: opencv-cn-lin-x86-64
     defaults:
       run:
@@ -372,13 +370,13 @@ jobs:
       id: java-test
       if: ${{ always() && steps.build-opencv-contrib.outcome == 'success' }}
       run: cd $HOME/build && xvfb-run -a python3 $HOME/opencv/modules/ts/misc/run.py . -a -t java
-    - name: Save Unit Test Results
-      timeout-minutes: 60
-      uses: actions/upload-artifact@v3
-      if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
-      with:
-        name: junit-html
-        path: /home/ci/build/java_test/testResults/junit-noframes.html
+    # - name: Save Unit Test Results
+    #   timeout-minutes: 60
+    #   uses: actions/upload-artifact@v3
+    #   if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
+    #   with:
+    #     name: junit-html
+    #     path: /home/ci/build/java_test/testResults/junit-noframes.html
     - name: Pylint
       timeout-minutes: 60
       if: ${{ always() && steps.build-opencv-contrib.outcome == 'success' }}

--- a/.github/workflows/OCV-Contrib-PR-3.4-macOS-ARM64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-3.4-macOS-ARM64.yaml
@@ -21,8 +21,6 @@ env:
 
 jobs:
   BuildAndTest:
-    # Temporarily disabled this job
-    if: ${{ github.event.repository.name == 'disabled' }}
     runs-on: opencv-cn-mac-arm64
     defaults:
       run:
@@ -424,10 +422,10 @@ jobs:
       if: ${{ always() && steps.build-opencv-contrib.outcome == 'success' }}
       run: python3 ../opencv/modules/ts/misc/run.py . -a -t java
       working-directory: ${{ github.workspace }}/build
-    - name: Save Unit Test Results
-      timeout-minutes: 60
-      uses: actions/upload-artifact@v3
-      if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
-      with:
-        name: junit-html
-        path: build/java_test/testResults/junit-noframes.html
+    # - name: Save Unit Test Results
+    #   timeout-minutes: 60
+    #   uses: actions/upload-artifact@v3
+    #   if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
+    #   with:
+    #     name: junit-html
+    #     path: build/java_test/testResults/junit-noframes.html

--- a/.github/workflows/OCV-Contrib-PR-3.4-macOS-x86_64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-3.4-macOS-x86_64.yaml
@@ -21,8 +21,6 @@ env:
 
 jobs:
   BuildAndTest:
-    # Temporarily disabled this job
-    if: ${{ github.event.repository.name == 'disabled' }}
     runs-on: opencv-cn-mac-x86-64
     defaults:
       run:
@@ -424,10 +422,10 @@ jobs:
       if: ${{ always() && steps.build-opencv-contrib.outcome == 'success' }}
       run: python3 ../opencv/modules/ts/misc/run.py . -a -t java
       working-directory: ${{ github.workspace }}/build
-    - name: Save Unit Test Results
-      timeout-minutes: 60
-      uses: actions/upload-artifact@v3
-      if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
-      with:
-        name: junit-html
-        path: build/java_test/testResults/junit-noframes.html
+    # - name: Save Unit Test Results
+    #   timeout-minutes: 60
+    #   uses: actions/upload-artifact@v3
+    #   if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
+    #   with:
+    #     name: junit-html
+    #     path: build/java_test/testResults/junit-noframes.html

--- a/.github/workflows/OCV-Contrib-PR-4.x-ARM64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-4.x-ARM64.yaml
@@ -25,8 +25,6 @@ env:
 
 jobs:
   BuildAndTest:
-    # Temporarily disabled this job
-    if: ${{ github.event.repository.name == 'disabled' }}
     runs-on: opencv-cn-lin-arm64
     defaults:
       run:
@@ -416,10 +414,10 @@ jobs:
       id: java-test
       if: ${{ always() && steps.build-opencv-contrib.outcome == 'success' }}
       run: cd $HOME/build && xvfb-run -a python3 $HOME/opencv/modules/ts/misc/run.py . -a -t java
-    - name: Save Unit Test Results
-      timeout-minutes: 60
-      uses: actions/upload-artifact@v3
-      if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
-      with:
-        name: junit-html
-        path: /home/ci/build/java_test/testResults/junit-noframes.html
+    # - name: Save Unit Test Results
+    #   timeout-minutes: 60
+    #   uses: actions/upload-artifact@v3
+    #   if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
+    #   with:
+    #     name: junit-html
+    #     path: /home/ci/build/java_test/testResults/junit-noframes.html

--- a/.github/workflows/OCV-Contrib-PR-4.x-U20.yaml
+++ b/.github/workflows/OCV-Contrib-PR-4.x-U20.yaml
@@ -25,8 +25,6 @@ env:
 
 jobs:
   BuildAndTest:
-    # Temporarily disabled this job
-    if: ${{ github.event.repository.name == 'disabled' }}
     runs-on: opencv-cn-lin-x86-64
     defaults:
       run:
@@ -424,13 +422,13 @@ jobs:
       id: java-test
       if: ${{ always() && steps.build-opencv-contrib.outcome == 'success' }}
       run: cd $HOME/build && xvfb-run -a python3 $HOME/opencv/modules/ts/misc/run.py . -a -t java
-    - name: Save Unit Test Results
-      timeout-minutes: 60
-      uses: actions/upload-artifact@v3
-      if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
-      with:
-        name: junit-html
-        path: /home/ci/build/java_test/testResults/junit-noframes.html
+    # - name: Save Unit Test Results
+    #   timeout-minutes: 60
+    #   uses: actions/upload-artifact@v3
+    #   if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
+    #   with:
+    #     name: junit-html
+    #     path: /home/ci/build/java_test/testResults/junit-noframes.html
     - name: Pylint
       timeout-minutes: 60
       if: ${{ always() && steps.build-opencv-contrib.outcome == 'success' }}

--- a/.github/workflows/OCV-Contrib-PR-4.x-macOS-ARM64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-4.x-macOS-ARM64.yaml
@@ -21,8 +21,6 @@ env:
 
 jobs:
   BuildAndTest:
-    # Temporarily disabled this job
-    if: ${{ github.event.repository.name == 'disabled' }}
     runs-on: opencv-cn-mac-arm64
     defaults:
       run:
@@ -488,10 +486,10 @@ jobs:
       if: ${{ always() && steps.build-opencv-contrib.outcome == 'success' }}
       run: python3 ../opencv/modules/ts/misc/run.py . -a -t java
       working-directory: ${{ github.workspace }}/build
-    - name: Save Unit Test Results
-      timeout-minutes: 60
-      uses: actions/upload-artifact@v3
-      if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
-      with:
-        name: junit-html
-        path: build/java_test/testResults/junit-noframes.html
+    # - name: Save Unit Test Results
+    #   timeout-minutes: 60
+    #   uses: actions/upload-artifact@v3
+    #   if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
+    #   with:
+    #     name: junit-html
+    #     path: build/java_test/testResults/junit-noframes.html

--- a/.github/workflows/OCV-Contrib-PR-4.x-macOS-x86_64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-4.x-macOS-x86_64.yaml
@@ -21,8 +21,6 @@ env:
 
 jobs:
   BuildAndTest:
-    # Temporarily disabled this job
-    if: ${{ github.event.repository.name == 'disabled' }}
     runs-on: opencv-cn-mac-x86-64
     defaults:
       run:
@@ -489,10 +487,10 @@ jobs:
       if: ${{ always() && steps.build-opencv-contrib.outcome == 'success' }}
       run: python3 ../opencv/modules/ts/misc/run.py . -a -t java
       working-directory: ${{ github.workspace }}/build
-    - name: Save Unit Test Results
-      timeout-minutes: 60
-      uses: actions/upload-artifact@v3
-      if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
-      with:
-        name: junit-html
-        path: build/java_test/testResults/junit-noframes.html
+    # - name: Save Unit Test Results
+    #   timeout-minutes: 60
+    #   uses: actions/upload-artifact@v3
+    #   if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
+    #   with:
+    #     name: junit-html
+    #     path: build/java_test/testResults/junit-noframes.html

--- a/.github/workflows/OCV-Contrib-PR-5.x-ARM64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-5.x-ARM64.yaml
@@ -25,8 +25,6 @@ env:
 
 jobs:
   BuildAndTest:
-    # Temporarily disabled this job
-    if: ${{ github.event.repository.name == 'disabled' }}
     runs-on: opencv-cn-lin-arm64
     defaults:
       run:
@@ -428,10 +426,10 @@ jobs:
       id: java-test
       if: ${{ always() && steps.build-opencv-contrib.outcome == 'success' }}
       run: cd $HOME/build && xvfb-run -a python3 $HOME/opencv/modules/ts/misc/run.py . -a -t java
-    - name: Save Unit Test Results
-      timeout-minutes: 60
-      uses: actions/upload-artifact@v3
-      if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
-      with:
-        name: junit-html
-        path: /home/ci/build/java_test/testResults/junit-noframes.html
+    # - name: Save Unit Test Results
+    #   timeout-minutes: 60
+    #   uses: actions/upload-artifact@v3
+    #   if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
+    #   with:
+    #     name: junit-html
+    #     path: /home/ci/build/java_test/testResults/junit-noframes.html

--- a/.github/workflows/OCV-Contrib-PR-5.x-U20.yaml
+++ b/.github/workflows/OCV-Contrib-PR-5.x-U20.yaml
@@ -25,8 +25,6 @@ env:
 
 jobs:
   BuildAndTest:
-    # Temporarily disabled this job
-    if: ${{ github.event.repository.name == 'disabled' }}
     runs-on: opencv-cn-lin-x86-64
     defaults:
       run:
@@ -436,13 +434,13 @@ jobs:
       id: java-test
       if: ${{ always() && steps.build-opencv-contrib.outcome == 'success' }}
       run: cd $HOME/build && xvfb-run -a python3 $HOME/opencv/modules/ts/misc/run.py . -a -t java
-    - name: Save Unit Test Results
-      timeout-minutes: 60
-      uses: actions/upload-artifact@v3
-      if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
-      with:
-        name: junit-html
-        path: /home/ci/build/java_test/testResults/junit-noframes.html
+    # - name: Save Unit Test Results
+    #   timeout-minutes: 60
+    #   uses: actions/upload-artifact@v3
+    #   if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
+    #   with:
+    #     name: junit-html
+    #     path: /home/ci/build/java_test/testResults/junit-noframes.html
     - name: Pylint
       timeout-minutes: 60
       if: ${{ always() && steps.build-opencv-contrib.outcome == 'success' }}

--- a/.github/workflows/OCV-Contrib-PR-5.x-macOS-ARM64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-5.x-macOS-ARM64.yaml
@@ -21,8 +21,6 @@ env:
 
 jobs:
   BuildAndTest:
-    # Temporarily disabled this job
-    if: ${{ github.event.repository.name == 'disabled' }}
     runs-on: opencv-cn-mac-arm64
     defaults:
       run:
@@ -501,10 +499,10 @@ jobs:
       if: ${{ always() && steps.build-opencv-contrib.outcome == 'success' }}
       run: python3 ../opencv/modules/ts/misc/run.py . -a -t java
       working-directory: ${{ github.workspace }}/build
-    - name: Save Unit Test Results
-      timeout-minutes: 60
-      uses: actions/upload-artifact@v3
-      if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
-      with:
-        name: junit-html
-        path: build/java_test/testResults/junit-noframes.html
+    # - name: Save Unit Test Results
+    #   timeout-minutes: 60
+    #   uses: actions/upload-artifact@v3
+    #   if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
+    #   with:
+    #     name: junit-html
+    #     path: build/java_test/testResults/junit-noframes.html

--- a/.github/workflows/OCV-Contrib-PR-5.x-macOS-x86_64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-5.x-macOS-x86_64.yaml
@@ -21,8 +21,6 @@ env:
 
 jobs:
   BuildAndTest:
-    # Temporarily disabled this job
-    if: ${{ github.event.repository.name == 'disabled' }}
     runs-on: opencv-cn-mac-x86-64
     defaults:
       run:
@@ -504,10 +502,10 @@ jobs:
       if: ${{ always() && steps.build-opencv-contrib.outcome == 'success' }}
       run: python3 ../opencv/modules/ts/misc/run.py . -a -t java
       working-directory: ${{ github.workspace }}/build
-    - name: Save Unit Test Results
-      timeout-minutes: 60
-      uses: actions/upload-artifact@v3
-      if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
-      with:
-        name: junit-html
-        path: build/java_test/testResults/junit-noframes.html
+    # - name: Save Unit Test Results
+    #   timeout-minutes: 60
+    #   uses: actions/upload-artifact@v3
+    #   if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
+    #   with:
+    #     name: junit-html
+    #     path: build/java_test/testResults/junit-noframes.html

--- a/.github/workflows/OCV-PR-3.4-ARM64.yaml
+++ b/.github/workflows/OCV-PR-3.4-ARM64.yaml
@@ -24,8 +24,6 @@ env:
 
 jobs:
   BuildAndTest:
-    # Temporarily disabled this job
-    if: ${{ github.event.repository.name == 'disabled' }}
     runs-on: opencv-cn-lin-arm64
     defaults:
       run:
@@ -239,17 +237,15 @@ jobs:
       id: java-test
       if: ${{ always() && steps.build-opencv.outcome == 'success' }}
       run: cd $HOME/build && xvfb-run -a python3 ${{ env.OPENCV_DOCKER_WORKDIR }}/modules/ts/misc/run.py . -a -t java
-    - name: Save Unit Test Results
-      timeout-minutes: 60
-      uses: actions/upload-artifact@v3
-      if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
-      with:
-        name: junit-html
-        path: /home/ci/build/java_test/testResults/junit-noframes.html
+    # - name: Save Unit Test Results
+    #   timeout-minutes: 60
+    #   uses: actions/upload-artifact@v3
+    #   if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
+    #   with:
+    #     name: junit-html
+    #     path: /home/ci/build/java_test/testResults/junit-noframes.html
 
   BuildContrib:
-    # Temporarily disabled this job
-    if: ${{ github.event.repository.name == 'disabled' }}
     runs-on: opencv-cn-lin-arm64
     defaults:
       run:

--- a/.github/workflows/OCV-PR-3.4-Android.yaml
+++ b/.github/workflows/OCV-PR-3.4-Android.yaml
@@ -22,8 +22,6 @@ env:
 
 jobs:
   BuildAndTest:
-    # Temporarily disabled this job
-    if: ${{ github.event.repository.name == 'disabled' }}
     runs-on: opencv-cn-lin-x86-64
     defaults:
       run:
@@ -85,10 +83,10 @@ jobs:
       - name: Create Package
         timeout-minutes: 60
         run: cd /home/ci/build && zip -r -9 -y OpenCV3Android.zip OpenCV-android-sdk
-      - name: Release Package
-        timeout-minutes: 60
-        uses: actions/upload-artifact@v3
-        if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || env.RUNNER_DEBUG == 1 }}
-        with:
-          name: OpenCV3AndroidSDK
-          path: /home/ci/build/OpenCV3Android.zip
+      # - name: Release Package
+      #   timeout-minutes: 60
+      #   uses: actions/upload-artifact@v3
+      #   if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || env.RUNNER_DEBUG == 1 }}
+      #   with:
+      #     name: OpenCV3AndroidSDK
+      #     path: /home/ci/build/OpenCV3Android.zip

--- a/.github/workflows/OCV-PR-3.4-U14.yaml
+++ b/.github/workflows/OCV-PR-3.4-U14.yaml
@@ -24,8 +24,6 @@ env:
 
 jobs:
   BuildAndTest:
-    # Temporarily disabled this job
-    if: ${{ github.event.repository.name == 'disabled' }}
     runs-on: opencv-cn-lin-x86-64
     defaults:
       run:
@@ -240,17 +238,15 @@ jobs:
       id: java-test
       if: ${{ always() && steps.build-opencv.outcome == 'success' }}
       run: cd $HOME/build && xvfb-run -a python3 ${{ env.OPENCV_DOCKER_WORKDIR }}/modules/ts/misc/run.py . -a -t java
-    - name: Save Unit Test Results
-      timeout-minutes: 60
-      uses: actions/upload-artifact@v3
-      if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
-      with:
-        name: junit-html
-        path: /home/ci/build/java_test/testResults/junit-noframes.html
+    # - name: Save Unit Test Results
+    #   timeout-minutes: 60
+    #   uses: actions/upload-artifact@v3
+    #   if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
+    #   with:
+    #     name: junit-html
+    #     path: /home/ci/build/java_test/testResults/junit-noframes.html
 
   BuildContrib:
-    # Temporarily disabled this job
-    if: ${{ github.event.repository.name == 'disabled' }}
     runs-on: opencv-cn-lin-x86-64
     defaults:
       run:

--- a/.github/workflows/OCV-PR-3.4-U20.yaml
+++ b/.github/workflows/OCV-PR-3.4-U20.yaml
@@ -24,8 +24,6 @@ env:
 
 jobs:
   BuildAndTest:
-    # Temporarily disabled this job
-    if: ${{ github.event.repository.name == 'disabled' }}
     runs-on: opencv-cn-lin-x86-64
     defaults:
       run:
@@ -240,21 +238,19 @@ jobs:
       id: java-test
       if: ${{ always() && steps.build-opencv.outcome == 'success' }}
       run: cd $HOME/build && xvfb-run -a python3 ${{ env.OPENCV_DOCKER_WORKDIR }}/modules/ts/misc/run.py . -a -t java
-    - name: Save Unit Test Results
-      timeout-minutes: 60
-      uses: actions/upload-artifact@v3
-      if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
-      with:
-        name: junit-html
-        path: /home/ci/build/java_test/testResults/junit-noframes.html
+    # - name: Save Unit Test Results
+    #   timeout-minutes: 60
+    #   uses: actions/upload-artifact@v3
+    #   if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
+    #   with:
+    #     name: junit-html
+    #     path: /home/ci/build/java_test/testResults/junit-noframes.html
     - name: Pylint
       timeout-minutes: 60
       if: ${{ always() && steps.build-opencv.outcome == 'success' }}
       run: cd $HOME/build && cmake --build . --config release --target check_pylint -- -j4
 
   BuildContrib:
-    # Temporarily disabled this job
-    if: ${{ github.event.repository.name == 'disabled' }}
     runs-on: opencv-cn-lin-x86-64
     defaults:
       run:

--- a/.github/workflows/OCV-PR-3.4-macOS-ARM64.yaml
+++ b/.github/workflows/OCV-PR-3.4-macOS-ARM64.yaml
@@ -21,8 +21,6 @@ env:
 
 jobs:
   BuildAndTest:
-    # Temporarily disabled this job
-    if: ${{ github.event.repository.name == 'disabled' }}
     runs-on: opencv-cn-mac-arm64
     defaults:
       run:
@@ -262,17 +260,15 @@ jobs:
       if: ${{ always() && steps.build-opencv.outcome == 'success' }}
       run: python3 ../opencv/modules/ts/misc/run.py . -a -t java
       working-directory: ${{ github.workspace }}/build
-    - name: Save Unit Test Results
-      timeout-minutes: 60
-      uses: actions/upload-artifact@v3
-      if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
-      with:
-        name: junit-html
-        path: ${{ github.workspace }}/build/java_test/testResults/junit-noframes.html
+    # - name: Save Unit Test Results
+    #   timeout-minutes: 60
+    #   uses: actions/upload-artifact@v3
+    #   if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
+    #   with:
+    #     name: junit-html
+    #     path: ${{ github.workspace }}/build/java_test/testResults/junit-noframes.html
 
   BuildContrib:
-    # Temporarily disabled this job
-    if: ${{ github.event.repository.name == 'disabled' }}
     runs-on: opencv-cn-mac-arm64
     defaults:
       run:

--- a/.github/workflows/OCV-PR-3.4-macOS-x86_64.yaml
+++ b/.github/workflows/OCV-PR-3.4-macOS-x86_64.yaml
@@ -20,8 +20,6 @@ env:
 
 jobs:
   BuildAndTest:
-    # Temporarily disabled this job
-    if: ${{ github.event.repository.name == 'disabled' }}
     runs-on: opencv-cn-mac-x86-64
     defaults:
       run:
@@ -262,17 +260,15 @@ jobs:
       if: ${{ always() && steps.build-opencv.outcome == 'success' }}
       run: python3 ../opencv/modules/ts/misc/run.py . -a -t java
       working-directory: ${{ github.workspace }}/build
-    - name: Save Unit Test Results
-      timeout-minutes: 60
-      uses: actions/upload-artifact@v3
-      if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
-      with:
-        name: junit-html
-        path: ${{ github.workspace }}/build/java_test/testResults/junit-noframes.html
+    # - name: Save Unit Test Results
+    #   timeout-minutes: 60
+    #   uses: actions/upload-artifact@v3
+    #   if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
+    #   with:
+    #     name: junit-html
+    #     path: ${{ github.workspace }}/build/java_test/testResults/junit-noframes.html
 
   BuildContrib:
-    # Temporarily disabled this job
-    if: ${{ github.event.repository.name == 'disabled' }}
     runs-on: opencv-cn-mac-x86-64
     defaults:
       run:

--- a/.github/workflows/OCV-PR-4.x-ARM64.yaml
+++ b/.github/workflows/OCV-PR-4.x-ARM64.yaml
@@ -24,8 +24,6 @@ env:
 
 jobs:
   BuildAndTest:
-    # Temporarily disabled this job
-    if: ${{ github.event.repository.name == 'disabled' }}
     runs-on: opencv-cn-lin-arm64
     defaults:
       run:
@@ -223,17 +221,15 @@ jobs:
       id: java-test
       if: ${{ always() && steps.build-opencv.outcome == 'success' }}
       run: cd $HOME/build && xvfb-run -a python3 ${{ env.OPENCV_DOCKER_WORKDIR }}/modules/ts/misc/run.py . -a -t java
-    - name: Save Unit Test Results
-      timeout-minutes: 60
-      uses: actions/upload-artifact@v3
-      if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
-      with:
-        name: junit-html
-        path: /home/ci/build/java_test/testResults/junit-noframes.html
+    # - name: Save Unit Test Results
+    #   timeout-minutes: 60
+    #   uses: actions/upload-artifact@v3
+    #   if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
+    #   with:
+    #     name: junit-html
+    #     path: /home/ci/build/java_test/testResults/junit-noframes.html
 
   BuildContrib:
-    # Temporarily disabled this job
-    if: ${{ github.event.repository.name == 'disabled' }}
     runs-on: opencv-cn-lin-arm64
     defaults:
       run:

--- a/.github/workflows/OCV-PR-4.x-Android.yaml
+++ b/.github/workflows/OCV-PR-4.x-Android.yaml
@@ -22,8 +22,6 @@ env:
 
 jobs:
   BuildAndTest:
-    # Temporarily disabled this job
-    if: ${{ github.event.repository.name == 'disabled' }}
     runs-on: opencv-cn-lin-x86-64
     defaults:
       run:
@@ -83,10 +81,10 @@ jobs:
       - name: Create Package
         timeout-minutes: 60
         run: cd /home/ci/build && zip -r -9 -y OpenCV4Android.zip OpenCV-android-sdk
-      - name: Release Package
-        timeout-minutes: 60
-        uses: actions/upload-artifact@v3
-        if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || env.RUNNER_DEBUG == 1 }}
-        with:
-          name: OpenCV4AndroidSDK
-          path: /home/ci/build/OpenCV4Android.zip
+      # - name: Release Package
+      #   timeout-minutes: 60
+      #   uses: actions/upload-artifact@v3
+      #   if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || env.RUNNER_DEBUG == 1 }}
+      #   with:
+      #     name: OpenCV4AndroidSDK
+      #     path: /home/ci/build/OpenCV4Android.zip

--- a/.github/workflows/OCV-PR-4.x-U20.yaml
+++ b/.github/workflows/OCV-PR-4.x-U20.yaml
@@ -24,8 +24,6 @@ env:
 
 jobs:
   BuildAndTest:
-    # Temporarily disabled this job
-    if: ${{ github.event.repository.name == 'disabled' }}
     runs-on: opencv-cn-lin-x86-64
     defaults:
       run:
@@ -232,21 +230,19 @@ jobs:
       id: java-test
       if: ${{ always() && steps.build-opencv.outcome == 'success' }}
       run: cd $HOME/build && xvfb-run -a python3 ${{ env.OPENCV_DOCKER_WORKDIR }}/modules/ts/misc/run.py . -a -t java
-    - name: Save Unit Test Results
-      timeout-minutes: 60
-      uses: actions/upload-artifact@v3
-      if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
-      with:
-        name: junit-html
-        path: /home/ci/build/java_test/testResults/junit-noframes.html
+    # - name: Save Unit Test Results
+    #   timeout-minutes: 60
+    #   uses: actions/upload-artifact@v3
+    #   if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
+    #   with:
+    #     name: junit-html
+    #     path: /home/ci/build/java_test/testResults/junit-noframes.html
     - name: Pylint
       timeout-minutes: 60
       if: ${{ always() && steps.build-opencv.outcome == 'success' }}
       run: cd $HOME/build && cmake --build . --config release --target check_pylint -- -j4
 
   BuildContrib:
-    # Temporarily disabled this job
-    if: ${{ github.event.repository.name == 'disabled' }}
     runs-on: opencv-cn-lin-x86-64
     defaults:
       run:

--- a/.github/workflows/OCV-PR-4.x-iOS.yaml
+++ b/.github/workflows/OCV-PR-4.x-iOS.yaml
@@ -19,8 +19,6 @@ env:
 
 jobs:
   Build:
-    # Temporarily disabled this job
-    if: ${{ github.event.repository.name == 'disabled' }}
     runs-on: opencv-cn-mac-x86-64
     steps:
       - name: Setup environment
@@ -57,10 +55,10 @@ jobs:
       - name: Create Artifact
         timeout-minutes: 10
         run: cd ${{ github.workspace }}/ios && zip -r -9 -y opencv-4.x-ios-framework.zip opencv2.framework
-      - name: Upload Artifact
-        timeout-minutes: 60
-        uses: actions/upload-artifact@v3
-        if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || env.RUNNER_DEBUG == 1 }}
-        with:
-          name: OpenCViOSFramework
-          path: ${{ github.workspace }}/ios/opencv-4.x-ios-framework.zip
+      # - name: Upload Artifact
+      #   timeout-minutes: 60
+      #   uses: actions/upload-artifact@v3
+      #   if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || env.RUNNER_DEBUG == 1 }}
+      #   with:
+      #     name: OpenCViOSFramework
+      #     path: ${{ github.workspace }}/ios/opencv-4.x-ios-framework.zip

--- a/.github/workflows/OCV-PR-4.x-macOS-ARM64.yaml
+++ b/.github/workflows/OCV-PR-4.x-macOS-ARM64.yaml
@@ -21,8 +21,6 @@ env:
 
 jobs:
   BuildAndTest:
-    # Temporarily disabled this job
-    if: ${{ github.event.repository.name == 'disabled' }}
     runs-on: opencv-cn-mac-arm64
     defaults:
       run:
@@ -251,17 +249,15 @@ jobs:
       if: ${{ always() && steps.build-opencv.outcome == 'success' }}
       run: python3 ../opencv/modules/ts/misc/run.py . -a -t java
       working-directory: ${{ github.workspace }}/build
-    - name: Save Unit Test Results
-      timeout-minutes: 60
-      uses: actions/upload-artifact@v3
-      if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
-      with:
-        name: junit-html
-        path: ${{ github.workspace }}/build/java_test/testResults/junit-noframes.html
+    # - name: Save Unit Test Results
+    #   timeout-minutes: 60
+    #   uses: actions/upload-artifact@v3
+    #   if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
+    #   with:
+    #     name: junit-html
+    #     path: ${{ github.workspace }}/build/java_test/testResults/junit-noframes.html
 
   BuildContrib:
-    # Temporarily disabled this job
-    if: ${{ github.event.repository.name == 'disabled' }}
     runs-on: opencv-cn-mac-arm64
     defaults:
       run:

--- a/.github/workflows/OCV-PR-4.x-macOS-x86_64.yaml
+++ b/.github/workflows/OCV-PR-4.x-macOS-x86_64.yaml
@@ -20,8 +20,6 @@ env:
 
 jobs:
   BuildAndTest:
-    # Temporarily disabled this job
-    if: ${{ github.event.repository.name == 'disabled' }}
     runs-on: opencv-cn-mac-x86-64
     defaults:
       run:
@@ -252,17 +250,15 @@ jobs:
       if: ${{ always() && steps.build-opencv.outcome == 'success' }}
       run: python3 ../opencv/modules/ts/misc/run.py . -a -t java
       working-directory: ${{ github.workspace }}/build
-    - name: Save Unit Test Results
-      timeout-minutes: 60
-      uses: actions/upload-artifact@v3
-      if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
-      with:
-        name: junit-html
-        path: ${{ github.workspace }}/build/java_test/testResults/junit-noframes.html
+    # - name: Save Unit Test Results
+    #   timeout-minutes: 60
+    #   uses: actions/upload-artifact@v3
+    #   if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
+    #   with:
+    #     name: junit-html
+    #     path: ${{ github.workspace }}/build/java_test/testResults/junit-noframes.html
 
   BuildContrib:
-    # Temporarily disabled this job
-    if: ${{ github.event.repository.name == 'disabled' }}
     runs-on: opencv-cn-mac-x86-64
     defaults:
       run:

--- a/.github/workflows/OCV-PR-5.x-ARM64.yaml
+++ b/.github/workflows/OCV-PR-5.x-ARM64.yaml
@@ -24,8 +24,6 @@ env:
 
 jobs:
   BuildAndTest:
-    # Temporarily disabled this job
-    if: ${{ github.event.repository.name == 'disabled' }}
     runs-on: opencv-cn-lin-arm64
     defaults:
       run:
@@ -239,17 +237,15 @@ jobs:
       id: java-test
       if: ${{ always() && steps.build-opencv.outcome == 'success' }}
       run: cd $HOME/build && xvfb-run -a python3 ${{ env.OPENCV_DOCKER_WORKDIR }}/modules/ts/misc/run.py . -a -t java
-    - name: Save Unit Test Results
-      timeout-minutes: 60
-      uses: actions/upload-artifact@v3
-      if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
-      with:
-        name: junit-html
-        path: /home/ci/build/java_test/testResults/junit-noframes.html
+    # - name: Save Unit Test Results
+    #   timeout-minutes: 60
+    #   uses: actions/upload-artifact@v3
+    #   if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
+    #   with:
+    #     name: junit-html
+    #     path: /home/ci/build/java_test/testResults/junit-noframes.html
 
   BuildContrib:
-    # Temporarily disabled this job
-    if: ${{ github.event.repository.name == 'disabled' }}
     runs-on: opencv-cn-lin-arm64
     defaults:
       run:

--- a/.github/workflows/OCV-PR-5.x-Android.yaml
+++ b/.github/workflows/OCV-PR-5.x-Android.yaml
@@ -22,8 +22,6 @@ env:
 
 jobs:
   BuildAndTest:
-    # Temporarily disabled this job
-    if: ${{ github.event.repository.name == 'disabled' }}
     runs-on: opencv-cn-lin-x86-64
     defaults:
       run:
@@ -83,10 +81,10 @@ jobs:
       - name: Create Package
         timeout-minutes: 60
         run: cd /home/ci/build && zip -r -9 -y OpenCV5Android.zip OpenCV-android-sdk
-      - name: Release Package
-        timeout-minutes: 60
-        uses: actions/upload-artifact@v3
-        if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || env.RUNNER_DEBUG == 1 }}
-        with:
-          name: OpenCV5AndroidSDK
-          path: /home/ci/build/OpenCV5Android.zip
+      # - name: Release Package
+      #   timeout-minutes: 60
+      #   uses: actions/upload-artifact@v3
+      #   if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || env.RUNNER_DEBUG == 1 }}
+      #   with:
+      #     name: OpenCV5AndroidSDK
+      #     path: /home/ci/build/OpenCV5Android.zip

--- a/.github/workflows/OCV-PR-5.x-U20.yaml
+++ b/.github/workflows/OCV-PR-5.x-U20.yaml
@@ -24,8 +24,6 @@ env:
 
 jobs:
   BuildAndTest:
-    # Temporarily disabled this job
-    if: ${{ github.event.repository.name == 'disabled' }}
     runs-on: opencv-cn-lin-x86-64
     defaults:
       run:
@@ -247,21 +245,19 @@ jobs:
       id: java-test
       if: ${{ always() && steps.build-opencv.outcome == 'success' }}
       run: cd $HOME/build && xvfb-run -a python3 ${{ env.OPENCV_DOCKER_WORKDIR }}/modules/ts/misc/run.py . -a -t java
-    - name: Save Unit Test Results
-      timeout-minutes: 60
-      uses: actions/upload-artifact@v3
-      if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
-      with:
-        name: junit-html
-        path: /home/ci/build/java_test/testResults/junit-noframes.html
+    # - name: Save Unit Test Results
+    #   timeout-minutes: 60
+    #   uses: actions/upload-artifact@v3
+    #   if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
+    #   with:
+    #     name: junit-html
+    #     path: /home/ci/build/java_test/testResults/junit-noframes.html
     - name: Pylint
       timeout-minutes: 60
       if: ${{ always() && steps.build-opencv.outcome == 'success' }}
       run: cd $HOME/build && cmake --build . --config release --target check_pylint -- -j4
 
   BuildContrib:
-    # Temporarily disabled this job
-    if: ${{ github.event.repository.name == 'disabled' }}
     runs-on: opencv-cn-lin-x86-64
     defaults:
       run:

--- a/.github/workflows/OCV-PR-5.x-iOS.yaml
+++ b/.github/workflows/OCV-PR-5.x-iOS.yaml
@@ -19,8 +19,6 @@ env:
 
 jobs:
   Build:
-    # Temporarily disabled this job
-    if: ${{ github.event.repository.name == 'disabled' }}
     runs-on: opencv-cn-mac-x86-64
     steps:
       - name: Setup environment
@@ -57,10 +55,10 @@ jobs:
       - name: Create Artifact
         timeout-minutes: 10
         run: cd ${{ github.workspace }}/ios && zip -r -9 -y opencv-5.x-ios-framework.zip opencv2.framework
-      - name: Upload Artifact
-        timeout-minutes: 60
-        uses: actions/upload-artifact@v3
-        if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || env.RUNNER_DEBUG == 1 }}
-        with:
-          name: OpenCViOSFramework
-          path: ${{ github.workspace }}/ios/opencv-5.x-ios-framework.zip
+      # - name: Upload Artifact
+      #   timeout-minutes: 60
+      #   uses: actions/upload-artifact@v3
+      #   if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || env.RUNNER_DEBUG == 1 }}
+      #   with:
+      #     name: OpenCViOSFramework
+      #     path: ${{ github.workspace }}/ios/opencv-5.x-ios-framework.zip

--- a/.github/workflows/OCV-PR-5.x-macOS-ARM64.yaml
+++ b/.github/workflows/OCV-PR-5.x-macOS-ARM64.yaml
@@ -21,8 +21,6 @@ env:
 
 jobs:
   BuildAndTest:
-    # Temporarily disabled this job
-    if: ${{ github.event.repository.name == 'disabled' }}
     runs-on: opencv-cn-mac-arm64
     defaults:
       run:
@@ -271,17 +269,15 @@ jobs:
       if: ${{ always() && steps.build-opencv.outcome == 'success' }}
       run: python3 ../opencv/modules/ts/misc/run.py . -a -t java
       working-directory: ${{ github.workspace }}/build
-    - name: Save Unit Test Results
-      timeout-minutes: 60
-      uses: actions/upload-artifact@v3
-      if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
-      with:
-        name: junit-html
-        path: ${{ github.workspace }}/build/java_test/testResults/junit-noframes.html
+    # - name: Save Unit Test Results
+    #   timeout-minutes: 60
+    #   uses: actions/upload-artifact@v3
+    #   if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
+    #   with:
+    #     name: junit-html
+    #     path: ${{ github.workspace }}/build/java_test/testResults/junit-noframes.html
 
   BuildContrib:
-    # Temporarily disabled this job
-    if: ${{ github.event.repository.name == 'disabled' }}
     runs-on: opencv-cn-mac-arm64
     defaults:
       run:

--- a/.github/workflows/OCV-PR-5.x-macOS-x86_64.yaml
+++ b/.github/workflows/OCV-PR-5.x-macOS-x86_64.yaml
@@ -20,8 +20,6 @@ env:
 
 jobs:
   BuildAndTest:
-    # Temporarily disabled this job
-    if: ${{ github.event.repository.name == 'disabled' }}
     runs-on: opencv-cn-mac-x86-64
     defaults:
       run:
@@ -272,17 +270,15 @@ jobs:
       if: ${{ always() && steps.build-opencv.outcome == 'success' }}
       run: python3 ../opencv/modules/ts/misc/run.py . -a -t java
       working-directory: ${{ github.workspace }}/build
-    - name: Save Unit Test Results
-      timeout-minutes: 60
-      uses: actions/upload-artifact@v3
-      if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
-      with:
-        name: junit-html
-        path: ${{ github.workspace }}/build/java_test/testResults/junit-noframes.html
+    # - name: Save Unit Test Results
+    #   timeout-minutes: 60
+    #   uses: actions/upload-artifact@v3
+    #   if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
+    #   with:
+    #     name: junit-html
+    #     path: ${{ github.workspace }}/build/java_test/testResults/junit-noframes.html
 
   BuildContrib:
-    # Temporarily disabled this job
-    if: ${{ github.event.repository.name == 'disabled' }}
     runs-on: opencv-cn-mac-x86-64
     defaults:
       run:


### PR DESCRIPTION
This PR disables actions by GitHub like `actions/checkout` or `actions/upload-artifact` and turning on disabled workflows. 