### PR TITLE
Rename junit-html artifact by a platform

### DIFF
--- a/.github/workflows/OCV-Contrib-PR-3.4-ARM64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-3.4-ARM64.yaml
@@ -375,5 +375,5 @@ jobs:
       uses: actions/upload-artifact@v3
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
       with:
-        name: junit-html
+        name: junit-html-ubuntu20-arm64
         path: /home/ci/build/java_test/testResults/junit-noframes.html

--- a/.github/workflows/OCV-Contrib-PR-3.4-U14.yaml
+++ b/.github/workflows/OCV-Contrib-PR-3.4-U14.yaml
@@ -375,5 +375,5 @@ jobs:
       uses: actions/upload-artifact@v3
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
       with:
-        name: junit-html
+        name: junit-html-ubuntu14-x86-64
         path: /home/ci/build/java_test/testResults/junit-noframes.html

--- a/.github/workflows/OCV-Contrib-PR-3.4-U20.yaml
+++ b/.github/workflows/OCV-Contrib-PR-3.4-U20.yaml
@@ -375,7 +375,7 @@ jobs:
       uses: actions/upload-artifact@v3
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
       with:
-        name: junit-html
+        name: junit-html-ubuntu20-x86-64
         path: /home/ci/build/java_test/testResults/junit-noframes.html
     - name: Pylint
       timeout-minutes: 60

--- a/.github/workflows/OCV-Contrib-PR-3.4-W10.yaml
+++ b/.github/workflows/OCV-Contrib-PR-3.4-W10.yaml
@@ -370,5 +370,5 @@ jobs:
       uses: actions/upload-artifact@v3
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
       with:
-        name: junit-html
+        name: junit-html-windows10
         path: ${{ github.workspace }}\build\java_test\testResults\junit-noframes.html

--- a/.github/workflows/OCV-Contrib-PR-3.4-macOS-ARM64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-3.4-macOS-ARM64.yaml
@@ -427,5 +427,5 @@ jobs:
       uses: actions/upload-artifact@v3
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
       with:
-        name: junit-html
+        name: junit-html-macos-arm64
         path: build/java_test/testResults/junit-noframes.html

--- a/.github/workflows/OCV-Contrib-PR-3.4-macOS-x86_64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-3.4-macOS-x86_64.yaml
@@ -427,5 +427,5 @@ jobs:
       uses: actions/upload-artifact@v3
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
       with:
-        name: junit-html
+        name: junit-html-macos-x86-64
         path: build/java_test/testResults/junit-noframes.html

--- a/.github/workflows/OCV-Contrib-PR-4.x-ARM64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-4.x-ARM64.yaml
@@ -429,5 +429,5 @@ jobs:
       uses: actions/upload-artifact@v3
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
       with:
-        name: junit-html
+        name: junit-html-ubuntu20-arm64
         path: /home/ci/build/java_test/testResults/junit-noframes.html

--- a/.github/workflows/OCV-Contrib-PR-4.x-U20.yaml
+++ b/.github/workflows/OCV-Contrib-PR-4.x-U20.yaml
@@ -437,7 +437,7 @@ jobs:
       uses: actions/upload-artifact@v3
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
       with:
-        name: junit-html
+        name: junit-html-ubuntu20-x86-64
         path: /home/ci/build/java_test/testResults/junit-noframes.html
     - name: Pylint
       timeout-minutes: 60

--- a/.github/workflows/OCV-Contrib-PR-4.x-W10.yaml
+++ b/.github/workflows/OCV-Contrib-PR-4.x-W10.yaml
@@ -428,5 +428,5 @@ jobs:
       uses: actions/upload-artifact@v3
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
       with:
-        name: junit-html
+        name: junit-html-windows10
         path: ${{ github.workspace }}\build\java_test\testResults\junit-noframes.html

--- a/.github/workflows/OCV-Contrib-PR-4.x-macOS-ARM64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-4.x-macOS-ARM64.yaml
@@ -501,5 +501,5 @@ jobs:
       uses: actions/upload-artifact@v3
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
       with:
-        name: junit-html
+        name: junit-html-macos-arm64
         path: build/java_test/testResults/junit-noframes.html

--- a/.github/workflows/OCV-Contrib-PR-4.x-macOS-x86_64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-4.x-macOS-x86_64.yaml
@@ -502,5 +502,5 @@ jobs:
       uses: actions/upload-artifact@v3
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
       with:
-        name: junit-html
+        name: junit-html-macos-x86-64
         path: build/java_test/testResults/junit-noframes.html

--- a/.github/workflows/OCV-Contrib-PR-5.x-ARM64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-5.x-ARM64.yaml
@@ -431,5 +431,5 @@ jobs:
       uses: actions/upload-artifact@v3
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
       with:
-        name: junit-html
+        name: junit-html-ubuntu20-arm64
         path: /home/ci/build/java_test/testResults/junit-noframes.html

--- a/.github/workflows/OCV-Contrib-PR-5.x-U20.yaml
+++ b/.github/workflows/OCV-Contrib-PR-5.x-U20.yaml
@@ -439,7 +439,7 @@ jobs:
       uses: actions/upload-artifact@v3
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
       with:
-        name: junit-html
+        name: junit-html-ubuntu20-x86-64
         path: /home/ci/build/java_test/testResults/junit-noframes.html
     - name: Pylint
       timeout-minutes: 60

--- a/.github/workflows/OCV-Contrib-PR-5.x-W10.yaml
+++ b/.github/workflows/OCV-Contrib-PR-5.x-W10.yaml
@@ -434,5 +434,5 @@ jobs:
       uses: actions/upload-artifact@v3
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
       with:
-        name: junit-html
+        name: junit-html-windows10
         path: ${{ github.workspace }}\build\java_test\testResults\junit-noframes.html

--- a/.github/workflows/OCV-Contrib-PR-5.x-macOS-ARM64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-5.x-macOS-ARM64.yaml
@@ -504,5 +504,5 @@ jobs:
       uses: actions/upload-artifact@v3
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
       with:
-        name: junit-html
+        name: junit-html-macos-arm64
         path: build/java_test/testResults/junit-noframes.html

--- a/.github/workflows/OCV-Contrib-PR-5.x-macOS-x86_64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-5.x-macOS-x86_64.yaml
@@ -507,5 +507,5 @@ jobs:
       uses: actions/upload-artifact@v3
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
       with:
-        name: junit-html
+        name: junit-html-macos-x86-64
         path: build/java_test/testResults/junit-noframes.html

--- a/.github/workflows/OCV-PR-3.4-ARM64.yaml
+++ b/.github/workflows/OCV-PR-3.4-ARM64.yaml
@@ -242,7 +242,7 @@ jobs:
       uses: actions/upload-artifact@v3
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
       with:
-        name: junit-html
+        name: junit-html-ubuntu20-arm64
         path: /home/ci/build/java_test/testResults/junit-noframes.html
 
   BuildContrib:

--- a/.github/workflows/OCV-PR-3.4-U14.yaml
+++ b/.github/workflows/OCV-PR-3.4-U14.yaml
@@ -243,7 +243,7 @@ jobs:
       uses: actions/upload-artifact@v3
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
       with:
-        name: junit-html
+        name: junit-html-ubuntu14-x86-64
         path: /home/ci/build/java_test/testResults/junit-noframes.html
 
   BuildContrib:

--- a/.github/workflows/OCV-PR-3.4-U20.yaml
+++ b/.github/workflows/OCV-PR-3.4-U20.yaml
@@ -243,7 +243,7 @@ jobs:
       uses: actions/upload-artifact@v3
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
       with:
-        name: junit-html
+        name: junit-html-ubuntu20-x86-64
         path: /home/ci/build/java_test/testResults/junit-noframes.html
     - name: Pylint
       timeout-minutes: 60

--- a/.github/workflows/OCV-PR-3.4-W10.yaml
+++ b/.github/workflows/OCV-PR-3.4-W10.yaml
@@ -246,7 +246,7 @@ jobs:
       uses: actions/upload-artifact@v3
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
       with:
-        name: junit-html
+        name: junit-html-windows10
         path: ${{ github.workspace }}\build\java_test\testResults\junit-noframes.html
 
   BuildContrib:

--- a/.github/workflows/OCV-PR-3.4-macOS-ARM64.yaml
+++ b/.github/workflows/OCV-PR-3.4-macOS-ARM64.yaml
@@ -265,7 +265,7 @@ jobs:
       uses: actions/upload-artifact@v3
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
       with:
-        name: junit-html
+        name: junit-html-macos-arm64
         path: ${{ github.workspace }}/build/java_test/testResults/junit-noframes.html
 
   BuildContrib:

--- a/.github/workflows/OCV-PR-3.4-macOS-x86_64.yaml
+++ b/.github/workflows/OCV-PR-3.4-macOS-x86_64.yaml
@@ -265,7 +265,7 @@ jobs:
       uses: actions/upload-artifact@v3
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
       with:
-        name: junit-html
+        name: junit-html-macos-x86-64
         path: ${{ github.workspace }}/build/java_test/testResults/junit-noframes.html
 
   BuildContrib:

--- a/.github/workflows/OCV-PR-4.x-ARM64.yaml
+++ b/.github/workflows/OCV-PR-4.x-ARM64.yaml
@@ -226,7 +226,7 @@ jobs:
       uses: actions/upload-artifact@v3
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
       with:
-        name: junit-html
+        name: junit-html-ubuntu20-arm64
         path: /home/ci/build/java_test/testResults/junit-noframes.html
 
   BuildContrib:

--- a/.github/workflows/OCV-PR-4.x-U20.yaml
+++ b/.github/workflows/OCV-PR-4.x-U20.yaml
@@ -235,7 +235,7 @@ jobs:
       uses: actions/upload-artifact@v3
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
       with:
-        name: junit-html
+        name: junit-html-ubuntu20-x86-64
         path: /home/ci/build/java_test/testResults/junit-noframes.html
     - name: Pylint
       timeout-minutes: 60

--- a/.github/workflows/OCV-PR-4.x-W10.yaml
+++ b/.github/workflows/OCV-PR-4.x-W10.yaml
@@ -238,7 +238,7 @@ jobs:
       uses: actions/upload-artifact@v3
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
       with:
-        name: junit-html
+        name: junit-html-windows10
         path: ${{ github.workspace }}\build\java_test\testResults\junit-noframes.html
 
   BuildContrib:

--- a/.github/workflows/OCV-PR-4.x-macOS-ARM64.yaml
+++ b/.github/workflows/OCV-PR-4.x-macOS-ARM64.yaml
@@ -254,7 +254,7 @@ jobs:
       uses: actions/upload-artifact@v3
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
       with:
-        name: junit-html
+        name: junit-html-macos-arm64
         path: ${{ github.workspace }}/build/java_test/testResults/junit-noframes.html
 
   BuildContrib:

--- a/.github/workflows/OCV-PR-4.x-macOS-x86_64.yaml
+++ b/.github/workflows/OCV-PR-4.x-macOS-x86_64.yaml
@@ -255,7 +255,7 @@ jobs:
       uses: actions/upload-artifact@v3
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
       with:
-        name: junit-html
+        name: junit-html-macos-x86-64
         path: ${{ github.workspace }}/build/java_test/testResults/junit-noframes.html
 
   BuildContrib:

--- a/.github/workflows/OCV-PR-5.x-ARM64.yaml
+++ b/.github/workflows/OCV-PR-5.x-ARM64.yaml
@@ -242,7 +242,7 @@ jobs:
       uses: actions/upload-artifact@v3
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
       with:
-        name: junit-html
+        name: junit-html-ubuntu20-arm64
         path: /home/ci/build/java_test/testResults/junit-noframes.html
 
   BuildContrib:

--- a/.github/workflows/OCV-PR-5.x-U20.yaml
+++ b/.github/workflows/OCV-PR-5.x-U20.yaml
@@ -250,7 +250,7 @@ jobs:
       uses: actions/upload-artifact@v3
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
       with:
-        name: junit-html
+        name: junit-html-ubuntu20-x86-64
         path: /home/ci/build/java_test/testResults/junit-noframes.html
     - name: Pylint
       timeout-minutes: 60

--- a/.github/workflows/OCV-PR-5.x-W10.yaml
+++ b/.github/workflows/OCV-PR-5.x-W10.yaml
@@ -254,7 +254,7 @@ jobs:
       uses: actions/upload-artifact@v3
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
       with:
-        name: junit-html
+        name: junit-html-windows10
         path: ${{ github.workspace }}\build\java_test\testResults\junit-noframes.html
 
   BuildContrib:

--- a/.github/workflows/OCV-PR-5.x-macOS-ARM64.yaml
+++ b/.github/workflows/OCV-PR-5.x-macOS-ARM64.yaml
@@ -274,7 +274,7 @@ jobs:
       uses: actions/upload-artifact@v3
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
       with:
-        name: junit-html
+        name: junit-html-macos-arm64
         path: ${{ github.workspace }}/build/java_test/testResults/junit-noframes.html
 
   BuildContrib:

--- a/.github/workflows/OCV-PR-5.x-macOS-x86_64.yaml
+++ b/.github/workflows/OCV-PR-5.x-macOS-x86_64.yaml
@@ -275,7 +275,7 @@ jobs:
       uses: actions/upload-artifact@v3
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
       with:
-        name: junit-html
+        name: junit-html-macos-x86-64
         path: ${{ github.workspace }}/build/java_test/testResults/junit-noframes.html
 
   BuildContrib:


### PR DESCRIPTION
This PR fixes a bug when one junit-html report replaces another and an artifact only for one platform is alive.