### PR TITLE
Fix the null `${{ github.event.pull_request.number }}` in concurrency group

### DIFF
--- a/.github/workflows/OCV-Contrib-PR-3.4-ARM64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-3.4-ARM64.yaml
@@ -9,7 +9,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: OCV-Contrib-PR-3.4-ARM64-${{ github.event.pull_request.number }}
+  group: OCV-Contrib-PR-3.4-ARM64-${{ github.event.number }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/OCV-Contrib-PR-3.4-U14.yaml
+++ b/.github/workflows/OCV-Contrib-PR-3.4-U14.yaml
@@ -9,7 +9,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: OCV-Contrib-PR-3.4-U14-${{ github.event.pull_request.number }}
+  group: OCV-Contrib-PR-3.4-U14-${{ github.event.number }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/OCV-Contrib-PR-3.4-U20.yaml
+++ b/.github/workflows/OCV-Contrib-PR-3.4-U20.yaml
@@ -9,7 +9,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: OCV-Contrib-PR-3.4-U20-${{ github.event.pull_request.number }}
+  group: OCV-Contrib-PR-3.4-U20-${{ github.event.number }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/OCV-Contrib-PR-3.4-W10.yaml
+++ b/.github/workflows/OCV-Contrib-PR-3.4-W10.yaml
@@ -9,7 +9,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: OCV-Contrib-PR-3.4-W10-${{ github.event.pull_request.number }}
+  group: OCV-Contrib-PR-3.4-W10-${{ github.event.number }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/OCV-Contrib-PR-3.4-macOS-ARM64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-3.4-macOS-ARM64.yaml
@@ -9,7 +9,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: OCV-Contrib-PR-3.4-macOS-ARM64-${{ github.event.pull_request.number }}
+  group: OCV-Contrib-PR-3.4-macOS-ARM64-${{ github.event.number }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/OCV-Contrib-PR-3.4-macOS-x86_64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-3.4-macOS-x86_64.yaml
@@ -9,7 +9,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: OCV-Contrib-PR-3.4-macOS-x86_64-${{ github.event.pull_request.number }}
+  group: OCV-Contrib-PR-3.4-macOS-x86_64-${{ github.event.number }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/OCV-Contrib-PR-4.x-ARM64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-4.x-ARM64.yaml
@@ -9,7 +9,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: OCV-Contrib-PR-4.x-ARM64-${{ github.event.pull_request.number }}
+  group: OCV-Contrib-PR-4.x-ARM64-${{ github.event.number }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/OCV-Contrib-PR-4.x-U20-Cuda.yaml
+++ b/.github/workflows/OCV-Contrib-PR-4.x-U20-Cuda.yaml
@@ -9,7 +9,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: OCV-Contrib-PR-4.x-U20-Cuda-${{ github.event.pull_request.number }}
+  group: OCV-Contrib-PR-4.x-U20-Cuda-${{ github.event.number }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/OCV-Contrib-PR-4.x-U20.yaml
+++ b/.github/workflows/OCV-Contrib-PR-4.x-U20.yaml
@@ -9,7 +9,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: OCV-Contrib-PR-4.x-U20-${{ github.event.pull_request.number }}
+  group: OCV-Contrib-PR-4.x-U20-${{ github.event.number }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/OCV-Contrib-PR-4.x-W10.yaml
+++ b/.github/workflows/OCV-Contrib-PR-4.x-W10.yaml
@@ -9,7 +9,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: OCV-Contrib-PR-4.x-W10-${{ github.event.pull_request.number }}
+  group: OCV-Contrib-PR-4.x-W10-${{ github.event.number }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/OCV-Contrib-PR-4.x-macOS-ARM64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-4.x-macOS-ARM64.yaml
@@ -9,7 +9,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: OCV-Contrib-PR-4.x-macOS-ARM64-${{ github.event.pull_request.number }}
+  group: OCV-Contrib-PR-4.x-macOS-ARM64-${{ github.event.number }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/OCV-Contrib-PR-4.x-macOS-x86_64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-4.x-macOS-x86_64.yaml
@@ -9,7 +9,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: OCV-Contrib-PR-4.x-macOS-x86_64-${{ github.event.pull_request.number }}
+  group: OCV-Contrib-PR-4.x-macOS-x86_64-${{ github.event.number }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/OCV-Contrib-PR-5.x-ARM64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-5.x-ARM64.yaml
@@ -9,7 +9,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: OCV-Contrib-PR-5.x-ARM64-${{ github.event.pull_request.number }}
+  group: OCV-Contrib-PR-5.x-ARM64-${{ github.event.number }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/OCV-Contrib-PR-5.x-U20-Cuda.yaml
+++ b/.github/workflows/OCV-Contrib-PR-5.x-U20-Cuda.yaml
@@ -9,7 +9,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: OCV-Contrib-PR-5.x-U20-Cuda-${{ github.event.pull_request.number }}
+  group: OCV-Contrib-PR-5.x-U20-Cuda-${{ github.event.number }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/OCV-Contrib-PR-5.x-U20.yaml
+++ b/.github/workflows/OCV-Contrib-PR-5.x-U20.yaml
@@ -9,7 +9,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: OCV-Contrib-PR-5.x-U20-${{ github.event.pull_request.number }}
+  group: OCV-Contrib-PR-5.x-U20-${{ github.event.number }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/OCV-Contrib-PR-5.x-W10.yaml
+++ b/.github/workflows/OCV-Contrib-PR-5.x-W10.yaml
@@ -9,7 +9,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: OCV-Contrib-PR-5.x-W10-${{ github.event.pull_request.number }}
+  group: OCV-Contrib-PR-5.x-W10-${{ github.event.number }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/OCV-Contrib-PR-5.x-macOS-ARM64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-5.x-macOS-ARM64.yaml
@@ -9,7 +9,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: OCV-Contrib-PR-5.x-macOS-ARM64-${{ github.event.pull_request.number }}
+  group: OCV-Contrib-PR-5.x-macOS-ARM64-${{ github.event.number }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/OCV-Contrib-PR-5.x-macOS-x86_64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-5.x-macOS-x86_64.yaml
@@ -9,7 +9,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: OCV-Contrib-PR-5.x-macOS-x86_64-${{ github.event.pull_request.number }}
+  group: OCV-Contrib-PR-5.x-macOS-x86_64-${{ github.event.number }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/OCV-Contrib-WinPack-4.x-W10.yaml
+++ b/.github/workflows/OCV-Contrib-WinPack-4.x-W10.yaml
@@ -11,7 +11,7 @@ on:
     - cron: '0 0 * * *'
 
 concurrency:
-  group: OCV-Contrib-WinPack-4.x-W10-${{ github.event.pull_request.number }}
+  group: OCV-Contrib-WinPack-4.x-W10-${{ github.event.number }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/OCV-Coverage-4.x-U20.yaml
+++ b/.github/workflows/OCV-Coverage-4.x-U20.yaml
@@ -11,7 +11,7 @@ on:
   schedule:
     - cron: '0 0 * * 6'
 concurrency:
-  group: OCV-Coverage-4.x-U20-${{ github.event.pull_request.number }}
+  group: OCV-Coverage-4.x-U20-${{ github.event.number }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/OCV-DNN-models-update.yaml
+++ b/.github/workflows/OCV-DNN-models-update.yaml
@@ -10,7 +10,7 @@ on:
     - cron: '0 23 * * *'
 
 concurrency:
-  group: OCV-DNN-models-update-${{ github.event.pull_request.number }}
+  group: OCV-DNN-models-update-${{ github.event.number }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/OCV-Git-Cache.yaml
+++ b/.github/workflows/OCV-Git-Cache.yaml
@@ -10,7 +10,7 @@ on:
     - cron: '0 0 * * *'
 
 concurrency:
-  group: OCV-Git-Cache-${{ github.event.pull_request.number }}
+  group: OCV-Git-Cache-${{ github.event.number }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/OCV-Nightly-docs-js.yaml
+++ b/.github/workflows/OCV-Nightly-docs-js.yaml
@@ -11,7 +11,7 @@ on:
     - cron: '0 0 * * *'
 
 concurrency:
-  group: OCV-Nightly-docs-js-${{ github.event.pull_request.number }}
+  group: OCV-Nightly-docs-js-${{ github.event.number }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/OCV-PR-3.4-ARM64.yaml
+++ b/.github/workflows/OCV-PR-3.4-ARM64.yaml
@@ -9,7 +9,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: OCV-PR-3.4-ARM64-${{ github.event.pull_request.number }}
+  group: OCV-PR-3.4-ARM64-${{ github.event.number }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/OCV-PR-3.4-Android.yaml
+++ b/.github/workflows/OCV-PR-3.4-Android.yaml
@@ -12,7 +12,7 @@ on:
     - cron: '0 0 * * *'
 
 concurrency:
-  group: OCV-PR-3.4-Android-${{ github.event.pull_request.number }}
+  group: OCV-PR-3.4-Android-${{ github.event.number }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/OCV-PR-3.4-U14.yaml
+++ b/.github/workflows/OCV-PR-3.4-U14.yaml
@@ -9,7 +9,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: OCV-PR-3.4-U14-${{ github.event.pull_request.number }}
+  group: OCV-PR-3.4-U14-${{ github.event.number }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/OCV-PR-3.4-U20.yaml
+++ b/.github/workflows/OCV-PR-3.4-U20.yaml
@@ -9,7 +9,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: OCV-PR-3.4-U20-${{ github.event.pull_request.number }}
+  group: OCV-PR-3.4-U20-${{ github.event.number }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/OCV-PR-3.4-W10.yaml
+++ b/.github/workflows/OCV-PR-3.4-W10.yaml
@@ -9,7 +9,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: OCV-PR-3.4-W10-${{ github.event.pull_request.number }}
+  group: OCV-PR-3.4-W10-${{ github.event.number }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/OCV-PR-3.4-docs.yaml
+++ b/.github/workflows/OCV-PR-3.4-docs.yaml
@@ -9,7 +9,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: OCV-PR-3.4-docs-${{ github.event.pull_request.number }}
+  group: OCV-PR-3.4-docs-${{ github.event.number }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/OCV-PR-3.4-iOS.yaml
+++ b/.github/workflows/OCV-PR-3.4-iOS.yaml
@@ -12,7 +12,7 @@ on:
     - cron: '0 0 * * *'
 
 concurrency:
-  group: OCV-PR-3.4-iOS-${{ github.event.pull_request.number }}
+  group: OCV-PR-3.4-iOS-${{ github.event.number }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/OCV-PR-3.4-macOS-ARM64.yaml
+++ b/.github/workflows/OCV-PR-3.4-macOS-ARM64.yaml
@@ -9,7 +9,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: OCV-PR-3.4-macOS-ARM64-${{ github.event.pull_request.number }}
+  group: OCV-PR-3.4-macOS-ARM64-${{ github.event.number }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/OCV-PR-3.4-macOS-x86_64.yaml
+++ b/.github/workflows/OCV-PR-3.4-macOS-x86_64.yaml
@@ -9,7 +9,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: OCV-PR-3.4-macOS-x86_64-${{ github.event.pull_request.number }}
+  group: OCV-PR-3.4-macOS-x86_64-${{ github.event.number }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/OCV-PR-4.x-ARM64-Debug.yaml
+++ b/.github/workflows/OCV-PR-4.x-ARM64-Debug.yaml
@@ -9,7 +9,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: OCV-PR-4.x-ARM64-debug-${{ github.event.pull_request.number }}
+  group: OCV-PR-4.x-ARM64-debug-${{ github.event.number }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/OCV-PR-4.x-ARM64.yaml
+++ b/.github/workflows/OCV-PR-4.x-ARM64.yaml
@@ -9,7 +9,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: OCV-PR-4.x-ARM64-${{ github.event.pull_request.number }}
+  group: OCV-PR-4.x-ARM64-${{ github.event.number }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/OCV-PR-4.x-Android.yaml
+++ b/.github/workflows/OCV-PR-4.x-Android.yaml
@@ -12,7 +12,7 @@ on:
     - cron: '0 0 * * *'
 
 concurrency:
-  group: OCV-PR-4.x-Android-${{ github.event.pull_request.number }}
+  group: OCV-PR-4.x-Android-${{ github.event.number }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/OCV-PR-4.x-U20-Cuda.yaml
+++ b/.github/workflows/OCV-PR-4.x-U20-Cuda.yaml
@@ -9,7 +9,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: OCV-PR-4.x-U20-Cuda-${{ github.event.pull_request.number }}
+  group: OCV-PR-4.x-U20-Cuda-${{ github.event.number }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/OCV-PR-4.x-U20.yaml
+++ b/.github/workflows/OCV-PR-4.x-U20.yaml
@@ -9,11 +9,13 @@ on:
   workflow_call:
 
 concurrency:
-  group: OCV-PR-4.x-U20-${{ github.event.pull_request.number }}
+  group: OCV-PR-4.x-U20-${{ github.event.number }}
   cancel-in-progress: true
 
 env:
   EXTRA_CMAKE_OPTIONS: '-DBUILD_DOCS=ON -DPYTHON_DEFAULT_EXECUTABLE=/usr/bin/python3 -DOPENCV_DOWNLOAD_PATH=/home/ci/binaries_cache -DBUILD_EXAMPLES=ON -DOPENCV_ENABLE_NONFREE=ON'
+  PR_NUMBER_NEW: ${{ github.event.number }}
+  PR_NUMBER_OLD: ${{ github.event.pull_request.number }}
   PR_AUTHOR: ${{ github.event.pull_request.user.login }}
   PR_AUTHOR_FORK: ${{ github.event.pull_request.head.repo.full_name }}
   SOURCE_BRANCH_NAME: ${{ github.head_ref }}
@@ -53,6 +55,8 @@ jobs:
     - name: PR info
       timeout-minutes: 60
       run: |
+        echo "PR number (new approach): ${{ env.PR_NUMBER_NEW }}"
+        echo "PR number (old approach): ${{ env.PR_NUMBER_OLD }}"
         echo "PR Author: ${{ env.PR_AUTHOR }}"
         echo "PR Author fork: ${{ env.PR_AUTHOR_FORK }}"
         echo "Source branch name: ${{ env.SOURCE_BRANCH_NAME }}"

--- a/.github/workflows/OCV-PR-4.x-W10.yaml
+++ b/.github/workflows/OCV-PR-4.x-W10.yaml
@@ -9,7 +9,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: OCV-PR-4.x-W10-${{ github.event.pull_request.number }}
+  group: OCV-PR-4.x-W10-${{ github.event.number }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/OCV-PR-4.x-docs.yaml
+++ b/.github/workflows/OCV-PR-4.x-docs.yaml
@@ -9,7 +9,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: OCV-PR-4.x-docs-${{ github.event.pull_request.number }}
+  group: OCV-PR-4.x-docs-${{ github.event.number }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/OCV-PR-4.x-iOS.yaml
+++ b/.github/workflows/OCV-PR-4.x-iOS.yaml
@@ -12,7 +12,7 @@ on:
     - cron: '0 0 * * *'
 
 concurrency:
-  group: OCV-PR-4.x-iOS-${{ github.event.pull_request.number }}
+  group: OCV-PR-4.x-iOS-${{ github.event.number }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/OCV-PR-4.x-macOS-ARM64.yaml
+++ b/.github/workflows/OCV-PR-4.x-macOS-ARM64.yaml
@@ -9,7 +9,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: OCV-PR-4.x-macOS-ARM64-${{ github.event.pull_request.number }}
+  group: OCV-PR-4.x-macOS-ARM64-${{ github.event.number }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/OCV-PR-4.x-macOS-x86_64.yaml
+++ b/.github/workflows/OCV-PR-4.x-macOS-x86_64.yaml
@@ -9,7 +9,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: OCV-PR-4.x-macOS-x86_64-${{ github.event.pull_request.number }}
+  group: OCV-PR-4.x-macOS-x86_64-${{ github.event.number }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/OCV-PR-5.x-ARM64-Debug.yaml
+++ b/.github/workflows/OCV-PR-5.x-ARM64-Debug.yaml
@@ -9,7 +9,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: OCV-PR-5.x-ARM64-debug-${{ github.event.pull_request.number }}
+  group: OCV-PR-5.x-ARM64-debug-${{ github.event.number }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/OCV-PR-5.x-ARM64.yaml
+++ b/.github/workflows/OCV-PR-5.x-ARM64.yaml
@@ -9,7 +9,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: OCV-PR-5.x-ARM64-${{ github.event.pull_request.number }}
+  group: OCV-PR-5.x-ARM64-${{ github.event.number }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/OCV-PR-5.x-Android.yaml
+++ b/.github/workflows/OCV-PR-5.x-Android.yaml
@@ -12,7 +12,7 @@ on:
     - cron: '0 0 * * *'
 
 concurrency:
-  group: OCV-PR-5.x-Android-${{ github.event.pull_request.number }}
+  group: OCV-PR-5.x-Android-${{ github.event.number }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/OCV-PR-5.x-U20-Cuda.yaml
+++ b/.github/workflows/OCV-PR-5.x-U20-Cuda.yaml
@@ -9,7 +9,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: OCV-PR-5.x-U20-Cuda-${{ github.event.pull_request.number }}
+  group: OCV-PR-5.x-U20-Cuda-${{ github.event.number }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/OCV-PR-5.x-U20.yaml
+++ b/.github/workflows/OCV-PR-5.x-U20.yaml
@@ -9,7 +9,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: OCV-PR-5.x-U20-${{ github.event.pull_request.number }}
+  group: OCV-PR-5.x-U20-${{ github.event.number }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/OCV-PR-5.x-W10.yaml
+++ b/.github/workflows/OCV-PR-5.x-W10.yaml
@@ -9,7 +9,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: OCV-PR-5.x-W10-${{ github.event.pull_request.number }}
+  group: OCV-PR-5.x-W10-${{ github.event.number }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/OCV-PR-5.x-docs.yaml
+++ b/.github/workflows/OCV-PR-5.x-docs.yaml
@@ -9,7 +9,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: OCV-PR-5.x-docs-${{ github.event.pull_request.number }}
+  group: OCV-PR-5.x-docs-${{ github.event.number }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/OCV-PR-5.x-iOS.yaml
+++ b/.github/workflows/OCV-PR-5.x-iOS.yaml
@@ -12,7 +12,7 @@ on:
     - cron: '0 0 * * *'
 
 concurrency:
-  group: OCV-PR-5.x-iOS-${{ github.event.pull_request.number }}
+  group: OCV-PR-5.x-iOS-${{ github.event.number }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/OCV-PR-5.x-macOS-ARM64.yaml
+++ b/.github/workflows/OCV-PR-5.x-macOS-ARM64.yaml
@@ -9,7 +9,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: OCV-PR-5.x-macOS-ARM64-${{ github.event.pull_request.number }}
+  group: OCV-PR-5.x-macOS-ARM64-${{ github.event.number }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/OCV-PR-5.x-macOS-x86_64.yaml
+++ b/.github/workflows/OCV-PR-5.x-macOS-x86_64.yaml
@@ -9,7 +9,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: OCV-PR-5.x-macOS-x86_64-${{ github.event.pull_request.number }}
+  group: OCV-PR-5.x-macOS-x86_64-${{ github.event.number }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/OCV-WinPack-4.x-W10.yaml
+++ b/.github/workflows/OCV-WinPack-4.x-W10.yaml
@@ -11,7 +11,7 @@ on:
     - cron: '0 0 * * *'
 
 concurrency:
-  group: OCV-WinPack-4.x-W10-${{ github.event.pull_request.number }}
+  group: OCV-WinPack-4.x-W10-${{ github.event.number }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/OCV-timvx-backend-tests-4.x.yml
+++ b/.github/workflows/OCV-timvx-backend-tests-4.x.yml
@@ -9,7 +9,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: OCV-timvx-backend-tests-4.x-${{ github.event.pull_request.number }}
+  group: OCV-timvx-backend-tests-4.x-${{ github.event.number }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
Fixes https://github.com/opencv/opencv/issues/22720

Notes:
- This bug is introduced in https://github.com/opencv/ci-gha-workflow/pull/74
  - The problem is `${{ github.event.pull_request.number }}` is null which puts jobs from different pull requests in a same lineup.
- [This comment](https://github.com/actions/checkout/issues/58#issuecomment-663103947) uses a different variable to get pull request number.
- [This solution](https://stackoverflow.com/a/71158335/6769366) uses a different key to distinguish different jobs from different pull requests.
- Github docs for context like `${{ github.xx }}`:
  - https://docs.github.com/en/actions/learn-github-actions/contexts#needs-context
  - https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows.