### PR TITLE
RISC-V: set git committer via environment

### DIFF
--- a/.github/workflows/OCV-Contrib-PR-4.x-RISCV.yaml
+++ b/.github/workflows/OCV-Contrib-PR-4.x-RISCV.yaml
@@ -26,6 +26,8 @@ env:
   OPENCV_DOCKER_WORKDIR: '/home/ci/opencv'
   PYTHONPATH: '/home/ci/build/python_loader:$PYTHONPATH'
   TEST_RUNNER: '/opt/riscv/bin/qemu-riscv64 -cpu rv64,v=true,vext_spec=v1.0 -L /opt/riscv/sysroot'
+  GIT_COMMITTER_NAME: 'nouser'
+  GIT_COMMITTER_EMAIL: 'noemail'
 
 jobs:
   BuildAndTest:

--- a/.github/workflows/OCV-PR-4.x-RISCV.yaml
+++ b/.github/workflows/OCV-PR-4.x-RISCV.yaml
@@ -26,6 +26,8 @@ env:
   OPENCV_DOCKER_WORKDIR: '/home/ci/opencv'
   PYTHONPATH: '/home/ci/build/python_loader:$PYTHONPATH'
   TEST_RUNNER: '/opt/riscv/bin/qemu-riscv64 -cpu rv64,v=true,vext_spec=v1.0 -L /opt/riscv/sysroot'
+  GIT_COMMITTER_NAME: 'nouser'
+  GIT_COMMITTER_EMAIL: 'noemail'
 
 jobs:
   BuildAndTest:


### PR DESCRIPTION
Looks like it's a git quirk/bug, because it does not make any commits with `pull --no-ff --no-rebase --no-commit` but requires user name/email to be set.