### PR TITLE
Upgrade Gradle in Android builds to 8.3.

### DIFF
--- a/.github/workflows/OCV-PR-4.x-Android.yaml
+++ b/.github/workflows/OCV-PR-4.x-Android.yaml
@@ -32,7 +32,7 @@ jobs:
       run:
         shell: bash
     container:
-      image: quay.io/opencv-ci/opencv-androidsdk-28:20220721
+      image: quay.io/opencv-ci/opencv-androidsdk-28:20231107
       volumes:
         - /home/opencv-cn/git_cache:/home/ci/git_cache
         - /home/opencv-cn/ci_cache/opencv:/home/ci/.ccache


### PR DESCRIPTION
Requires: https://github.com/opencv-infrastructure/opencv-gha-dockerfile/pull/25
Related: https://github.com/opencv/opencv/pull/24490