### PR TITLE
Force OPENCV_TEST_REQUIRE_DATA in CI environments in 4.x

### DIFF
--- a/.github/workflows/OCV-Contrib-PR-4.x-ARM64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-4.x-ARM64.yaml
@@ -22,6 +22,7 @@ env:
   GIT_CACHE_DOCKER: '/home/ci/git_cache'
   PYTHONPATH: /home/ci/build/python_loader:$PYTHONPATH
   OPENCV_TEST_DATA_PATH: '/home/ci/opencv_extra/testdata'
+  OPENCV_TEST_REQUIRE_DATA: 1
   OPENCV_CONTRIB_DOCKER_WORKDIR: '/home/ci/opencv_contrib'
   DNN_MODELS: '/home/ci/dnn-models'
   GTEST_FILTER_STRING: '-tracking_GOTURN.GOTURN/*'

--- a/.github/workflows/OCV-Contrib-PR-4.x-O22-CANN.yaml
+++ b/.github/workflows/OCV-Contrib-PR-4.x-O22-CANN.yaml
@@ -20,6 +20,7 @@ env:
   TARGET_BRANCH_NAME: ${{ github.base_ref }}
   GIT_CACHE_DOCKER: '/home/ci/git_cache'
   OPENCV_TEST_DATA_PATH: '/home/ci/opencv_extra/testdata'
+  OPENCV_TEST_REQUIRE_DATA: 1
   OPENCV_CONTRIB_DOCKER_WORKDIR: '/home/ci/opencv_contrib'
   PARALLEL_JOBS: 8
 

--- a/.github/workflows/OCV-Contrib-PR-4.x-RISCV.yaml
+++ b/.github/workflows/OCV-Contrib-PR-4.x-RISCV.yaml
@@ -22,6 +22,7 @@ env:
   GIT_CACHE_DOCKER: '/home/ci/git_cache'
   OPENCV_DOWNLOAD_PATH: '/home/ci/binaries_cache'
   OPENCV_TEST_DATA_PATH: '/home/ci/opencv_extra/testdata'
+  OPENCV_TEST_REQUIRE_DATA: 1
   OPENCV_CONTRIB_DOCKER_WORKDIR: '/home/ci/opencv_contrib'
   OPENCV_DOCKER_WORKDIR: '/home/ci/opencv'
   PYTHONPATH: '/home/ci/build/python_loader:$PYTHONPATH'

--- a/.github/workflows/OCV-Contrib-PR-4.x-U20-Cuda.yaml
+++ b/.github/workflows/OCV-Contrib-PR-4.x-U20-Cuda.yaml
@@ -21,6 +21,7 @@ env:
   ANT_HOME: '/usr/share/ant'
   GIT_CACHE_DOCKER: '/home/ci/git_cache'
   OPENCV_TEST_DATA_PATH: '/home/ci/opencv_extra/testdata'
+  OPENCV_TEST_REQUIRE_DATA: 1
   OPENCV_CONTRIB_DOCKER_WORKDIR: '/home/ci/opencv_contrib'
   PARALLEL_JOBS: 8
 

--- a/.github/workflows/OCV-Contrib-PR-4.x-U20.yaml
+++ b/.github/workflows/OCV-Contrib-PR-4.x-U20.yaml
@@ -22,6 +22,7 @@ env:
   GIT_CACHE_DOCKER: '/home/ci/git_cache'
   PYTHONPATH: /home/ci/build/python_loader:$PYTHONPATH
   OPENCV_TEST_DATA_PATH: '/home/ci/opencv_extra/testdata'
+  OPENCV_TEST_REQUIRE_DATA: 1
   OPENCV_CONTRIB_DOCKER_WORKDIR: '/home/ci/opencv_contrib'
   DNN_MODELS: '/home/ci/dnn-models'
   GTEST_FILTER_STRING: '-tracking_GOTURN.GOTURN/*'

--- a/.github/workflows/OCV-Contrib-PR-4.x-U22.yaml
+++ b/.github/workflows/OCV-Contrib-PR-4.x-U22.yaml
@@ -22,6 +22,7 @@ env:
   GIT_CACHE_DOCKER: '/home/ci/git_cache'
   PYTHONPATH: /home/ci/build/python_loader:$PYTHONPATH
   OPENCV_TEST_DATA_PATH: '/home/ci/opencv_extra/testdata'
+  OPENCV_TEST_REQUIRE_DATA: 1
   OPENCV_CONTRIB_DOCKER_WORKDIR: '/home/ci/opencv_contrib'
   DNN_MODELS: '/home/ci/dnn-models'
   # GStreamer 1.20 distributed with Ubuntu 22.04 as bug in JPEG integration

--- a/.github/workflows/OCV-Contrib-PR-4.x-W10.yaml
+++ b/.github/workflows/OCV-Contrib-PR-4.x-W10.yaml
@@ -19,6 +19,7 @@ env:
   SOURCE_BRANCH_NAME: ${{ github.head_ref }}
   TARGET_BRANCH_NAME: ${{ github.base_ref }}
   OPENCV_TEST_DATA_PATH: ${{ github.workspace }}\opencv_extra\testdata
+  OPENCV_TEST_REQUIRE_DATA: 1
   GTEST_FILTER_STRING: '-Samples.findFile:videoio/videocapture_acceleration.read/122:videoio/videocapture_acceleration.read/126'
   DOWNLOAD_DNN_MODELS_FILE: 'download_models.py'
 

--- a/.github/workflows/OCV-Contrib-PR-4.x-macOS-ARM64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-4.x-macOS-ARM64.yaml
@@ -21,6 +21,7 @@ env:
   ANT_HOME: '/usr/share/ant'
   PYTHONPATH: '${{ github.workspace }}/build/python_loader:$PYTHONPATH'
   OPENCV_TEST_DATA_PATH: '${{ github.workspace }}/opencv_extra/testdata'
+  OPENCV_TEST_REQUIRE_DATA: 1
   GTEST_FILTER_STRING: '-GOTURN.memory_usage:DaSiamRPN.memory_usage:videoio_dynamic.basic_write:Tracking_Boosting.Boosting/0:Tracking_Boosting.Boosting/1:Tracking_Boosting.Boosting/2:Tracking_TLD.TLD/0:Tracking_TLD.TLD/1:Tracking_TLD.TLD/2:Tracking/DistanceAndOverlap.TLD/2:Tracking/DistanceAndOverlap.Scaled_Data_TLD/2:videoio/videocapture_acceleration.read/64:videoio/videocapture_acceleration.read/65:videoio/videocapture_acceleration.read/66:videoio/videocapture_acceleration.read/67'
 
 jobs:

--- a/.github/workflows/OCV-Contrib-PR-4.x-macOS-x86_64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-4.x-macOS-x86_64.yaml
@@ -21,6 +21,7 @@ env:
   ANT_HOME: '/usr/share/ant'
   PYTHONPATH: '${{ github.workspace }}/build/python_loader:$PYTHONPATH'
   OPENCV_TEST_DATA_PATH: '${{ github.workspace }}/opencv_extra/testdata'
+  OPENCV_TEST_REQUIRE_DATA: 1
   GTEST_FILTER_STRING: '-tracking_GOTURN.GOTURN/*:Tracking/DistanceAndOverlap.TLD/2:Tracking/DistanceAndOverlap.Scaled_Data_TLD/2'
 
 jobs:

--- a/.github/workflows/OCV-PR-4.x-ARM64-Debug.yaml
+++ b/.github/workflows/OCV-PR-4.x-ARM64-Debug.yaml
@@ -94,7 +94,11 @@ jobs:
       timeout-minutes: 60
       run: |
         DOWNLOAD_MODELS_FILE='download_models.py'
-        LATEST_SAVED_HASH=$(cat ${{ env.DNN_MODELS }}/dnn/latest-hash-${{ env.TARGET_BRANCH_NAME }}.txt)
+        if [ -f ${{ env.DNN_MODELS }}/dnn/latest-hash-${{ env.TARGET_BRANCH_NAME }}.txt ]; then
+          LATEST_SAVED_HASH=$(cat ${{ env.DNN_MODELS }}/dnn/latest-hash-${{ env.TARGET_BRANCH_NAME }}.txt)
+        else
+          LATEST_SAVED_HASH=""
+        fi
         LATEST_HASH=$(sha256sum $HOME/opencv_extra/testdata/dnn/$DOWNLOAD_MODELS_FILE | awk '{print $1}')
         if [[ $LATEST_HASH == $LATEST_SAVED_HASH ]]; then
           echo "DNN models are up to date"

--- a/.github/workflows/OCV-PR-4.x-ARM64-Debug.yaml
+++ b/.github/workflows/OCV-PR-4.x-ARM64-Debug.yaml
@@ -22,6 +22,7 @@ env:
   GIT_CACHE_DOCKER: '/home/ci/git_cache'
   PYTHONPATH: /home/ci/build/python_loader:$PYTHONPATH
   OPENCV_TEST_DATA_PATH: '/home/ci/opencv_extra/testdata'
+  OPENCV_TEST_REQUIRE_DATA: 1
   OPENCV_DOCKER_WORKDIR: '/home/ci/opencv'
   PARALLEL_JOBS: 16
 

--- a/.github/workflows/OCV-PR-4.x-ARM64-Debug.yaml
+++ b/.github/workflows/OCV-PR-4.x-ARM64-Debug.yaml
@@ -22,7 +22,7 @@ env:
   GIT_CACHE_DOCKER: '/home/ci/git_cache'
   PYTHONPATH: /home/ci/build/python_loader:$PYTHONPATH
   OPENCV_TEST_DATA_PATH: '/home/ci/opencv_extra/testdata'
-  OPENCV_TEST_REQUIRE_DATA: 1
+  #OPENCV_TEST_REQUIRE_DATA: 1
   OPENCV_DOCKER_WORKDIR: '/home/ci/opencv'
   PARALLEL_JOBS: 16
 
@@ -90,27 +90,27 @@ jobs:
           echo "No merge since ${{ env.PR_AUTHOR }}/opencv_extra does not have branch ${{ env.SOURCE_BRANCH_NAME }}"
         fi
     # download models independently from DNN as some modules are used here and there on other places
-    - name: Extra DNN models update
-      timeout-minutes: 60
-      run: |
-        DOWNLOAD_MODELS_FILE='download_models.py'
-        if [ -f ${{ env.DNN_MODELS }}/dnn/latest-hash-${{ env.TARGET_BRANCH_NAME }}.txt ]; then
-          LATEST_SAVED_HASH=$(cat ${{ env.DNN_MODELS }}/dnn/latest-hash-${{ env.TARGET_BRANCH_NAME }}.txt)
-        else
-          LATEST_SAVED_HASH=""
-        fi
-        LATEST_HASH=$(sha256sum $HOME/opencv_extra/testdata/dnn/$DOWNLOAD_MODELS_FILE | awk '{print $1}')
-        if [[ $LATEST_HASH == $LATEST_SAVED_HASH ]]; then
-          echo "DNN models are up to date"
-          echo "OPENCV_DNN_TEST_DATA_PATH=${{ env.DNN_MODELS }}" >> $GITHUB_ENV
-        else
-          echo "Updating DNN models list"
-          echo "OPENCV_DNN_TEST_DATA_PATH=/home/ci/new-dnn-models" >> $GITHUB_ENV && OPENCV_DNN_TEST_DATA_PATH='/home/ci/new-dnn-models'
-          mkdir -p "$OPENCV_DNN_TEST_DATA_PATH"
-          rsync -a --exclude=$DOWNLOAD_MODELS_FILE ${{ env.DNN_MODELS }}/* $OPENCV_DNN_TEST_DATA_PATH
-          cp $HOME/opencv_extra/testdata/dnn/download_models.py $OPENCV_DNN_TEST_DATA_PATH/dnn
-          cd $OPENCV_DNN_TEST_DATA_PATH/dnn && python3 download_models.py
-        fi
+    #- name: Extra DNN models update
+      #timeout-minutes: 60
+      #run: |
+        #DOWNLOAD_MODELS_FILE='download_models.py'
+        #if [ -f ${{ env.DNN_MODELS }}/dnn/latest-hash-${{ env.TARGET_BRANCH_NAME }}.txt ]; then
+          #LATEST_SAVED_HASH=$(cat ${{ env.DNN_MODELS }}/dnn/latest-hash-${{ env.TARGET_BRANCH_NAME }}.txt)
+        #else
+          #LATEST_SAVED_HASH=""
+        #fi
+        #LATEST_HASH=$(sha256sum $HOME/opencv_extra/testdata/dnn/$DOWNLOAD_MODELS_FILE | awk '{print $1}')
+        #if [[ $LATEST_HASH == $LATEST_SAVED_HASH ]]; then
+          #echo "DNN models are up to date"
+          #echo "OPENCV_DNN_TEST_DATA_PATH=${{ env.DNN_MODELS }}" >> $GITHUB_ENV
+        #else
+          #echo "Updating DNN models list"
+          #echo "OPENCV_DNN_TEST_DATA_PATH=/home/ci/new-dnn-models" >> $GITHUB_ENV && OPENCV_DNN_TEST_DATA_PATH='/home/ci/new-dnn-models'
+          #mkdir -p "$OPENCV_DNN_TEST_DATA_PATH"
+          #rsync -a --exclude=$DOWNLOAD_MODELS_FILE ${{ env.DNN_MODELS }}/* $OPENCV_DNN_TEST_DATA_PATH
+          #cp $HOME/opencv_extra/testdata/dnn/download_models.py $OPENCV_DNN_TEST_DATA_PATH/dnn
+          #cd $OPENCV_DNN_TEST_DATA_PATH/dnn && python3 download_models.py
+        #fi
     - name: Configure OpenCV
       timeout-minutes: 60
       run: |

--- a/.github/workflows/OCV-PR-4.x-ARM64-Debug.yaml
+++ b/.github/workflows/OCV-PR-4.x-ARM64-Debug.yaml
@@ -89,6 +89,24 @@ jobs:
         else
           echo "No merge since ${{ env.PR_AUTHOR }}/opencv_extra does not have branch ${{ env.SOURCE_BRANCH_NAME }}"
         fi
+    # download models independently from DNN as some modules are used here and there on other places
+    - name: Extra DNN models update
+      timeout-minutes: 60
+      run: |
+        DOWNLOAD_MODELS_FILE='download_models.py'
+        LATEST_SAVED_HASH=$(cat ${{ env.DNN_MODELS }}/dnn/latest-hash-${{ env.TARGET_BRANCH_NAME }}.txt)
+        LATEST_HASH=$(sha256sum $HOME/opencv_extra/testdata/dnn/$DOWNLOAD_MODELS_FILE | awk '{print $1}')
+        if [[ $LATEST_HASH == $LATEST_SAVED_HASH ]]; then
+          echo "DNN models are up to date"
+          echo "OPENCV_DNN_TEST_DATA_PATH=${{ env.DNN_MODELS }}" >> $GITHUB_ENV
+        else
+          echo "Updating DNN models list"
+          echo "OPENCV_DNN_TEST_DATA_PATH=/home/ci/new-dnn-models" >> $GITHUB_ENV && OPENCV_DNN_TEST_DATA_PATH='/home/ci/new-dnn-models'
+          mkdir -p "$OPENCV_DNN_TEST_DATA_PATH"
+          rsync -a --exclude=$DOWNLOAD_MODELS_FILE ${{ env.DNN_MODELS }}/* $OPENCV_DNN_TEST_DATA_PATH
+          cp $HOME/opencv_extra/testdata/dnn/download_models.py $OPENCV_DNN_TEST_DATA_PATH/dnn
+          cd $OPENCV_DNN_TEST_DATA_PATH/dnn && python3 download_models.py
+        fi
     - name: Configure OpenCV
       timeout-minutes: 60
       run: |

--- a/.github/workflows/OCV-PR-4.x-ARM64.yaml
+++ b/.github/workflows/OCV-PR-4.x-ARM64.yaml
@@ -22,6 +22,7 @@ env:
   GIT_CACHE_DOCKER: '/home/ci/git_cache'
   PYTHONPATH: /home/ci/build/python_loader:$PYTHONPATH
   OPENCV_TEST_DATA_PATH: '/home/ci/opencv_extra/testdata'
+  OPENCV_TEST_REQUIRE_DATA: 1
   OPENCV_DOCKER_WORKDIR: '/home/ci/opencv'
   DNN_MODELS: '/home/ci/dnn-models'
   PARALLEL_JOBS: 16

--- a/.github/workflows/OCV-PR-4.x-RISCV.yaml
+++ b/.github/workflows/OCV-PR-4.x-RISCV.yaml
@@ -111,7 +111,7 @@ jobs:
         cmake -G Ninja \
           -S ${{ env.OPENCV_DOCKER_WORKDIR }} \
           -B $HOME/build \
-          ${{ env.EXTRA_CMAKE_OPTIONS }} 
+          ${{ env.EXTRA_CMAKE_OPTIONS }}
     - name: Build OpenCV
       timeout-minutes: 60
       id: build-opencv
@@ -222,7 +222,7 @@ jobs:
           -S ${{ env.OPENCV_DOCKER_WORKDIR }} \
           -B $HOME/build \
           -DOPENCV_EXTRA_MODULES_PATH=$HOME/opencv_contrib/modules \
-          ${{ env.EXTRA_CMAKE_OPTIONS }} 
+          ${{ env.EXTRA_CMAKE_OPTIONS }}
     - name: Build OpenCV Contrib
       timeout-minutes: 60
       run: |

--- a/.github/workflows/OCV-PR-4.x-U20-Cuda.yaml
+++ b/.github/workflows/OCV-PR-4.x-U20-Cuda.yaml
@@ -21,6 +21,7 @@ env:
   ANT_HOME: '/usr/share/ant'
   GIT_CACHE_DOCKER: '/home/ci/git_cache'
   OPENCV_TEST_DATA_PATH: '/home/ci/opencv_extra/testdata'
+  OPENCV_TEST_REQUIRE_DATA: 1
   OPENCV_DOCKER_WORKDIR: '/home/ci/opencv'
   DNN_MODELS: '/home/ci/dnn-models'
   PARALLEL_JOBS: 8

--- a/.github/workflows/OCV-PR-4.x-U20-OpenVINO.yaml
+++ b/.github/workflows/OCV-PR-4.x-U20-OpenVINO.yaml
@@ -21,6 +21,7 @@ env:
   GIT_CACHE_DOCKER: '/home/openvino/git_cache'
   PYTHONPATH: /home/openvino/build/python_loader:$PYTHONPATH
   OPENCV_TEST_DATA_PATH: '/home/openvino/opencv_extra/testdata'
+  OPENCV_TEST_REQUIRE_DATA: 1
   OPENCV_DOCKER_WORKDIR: '/home/openvino/opencv'
   DNN_MODELS: '/home/openvino/dnn-models'
   PARALLEL_JOBS: 8

--- a/.github/workflows/OCV-PR-4.x-U20-OpenVINO.yaml
+++ b/.github/workflows/OCV-PR-4.x-U20-OpenVINO.yaml
@@ -21,7 +21,7 @@ env:
   GIT_CACHE_DOCKER: '/home/openvino/git_cache'
   PYTHONPATH: /home/openvino/build/python_loader:$PYTHONPATH
   OPENCV_TEST_DATA_PATH: '/home/openvino/opencv_extra/testdata'
-  OPENCV_TEST_REQUIRE_DATA: 1
+  #OPENCV_TEST_REQUIRE_DATA: 1
   OPENCV_DOCKER_WORKDIR: '/home/openvino/opencv'
   DNN_MODELS: '/home/openvino/dnn-models'
   PARALLEL_JOBS: 8

--- a/.github/workflows/OCV-PR-4.x-U20.yaml
+++ b/.github/workflows/OCV-PR-4.x-U20.yaml
@@ -22,6 +22,7 @@ env:
   GIT_CACHE_DOCKER: '/home/ci/git_cache'
   PYTHONPATH: /home/ci/build/python_loader:$PYTHONPATH
   OPENCV_TEST_DATA_PATH: '/home/ci/opencv_extra/testdata'
+  OPENCV_TEST_REQUIRE_DATA: 1
   OPENCV_DOCKER_WORKDIR: '/home/ci/opencv'
   DNN_MODELS: '/home/ci/dnn-models'
   PARALLEL_JOBS: 8

--- a/.github/workflows/OCV-PR-4.x-U22.yaml
+++ b/.github/workflows/OCV-PR-4.x-U22.yaml
@@ -22,6 +22,7 @@ env:
   GIT_CACHE_DOCKER: '/home/ci/git_cache'
   PYTHONPATH: /home/ci/build/python_loader:$PYTHONPATH
   OPENCV_TEST_DATA_PATH: '/home/ci/opencv_extra/testdata'
+  OPENCV_TEST_REQUIRE_DATA: 1
   OPENCV_DOCKER_WORKDIR: '/home/ci/opencv'
   DNN_MODELS: '/home/ci/dnn-models'
   PARALLEL_JOBS: 8

--- a/.github/workflows/OCV-PR-4.x-W10-Vulkan.yaml
+++ b/.github/workflows/OCV-PR-4.x-W10-Vulkan.yaml
@@ -15,6 +15,7 @@ concurrency:
 env:
   EXTRA_CMAKE_OPTIONS: '-DCL_Z_OPTION=/Z7 -DOPENCV_DOWNLOAD_PATH=%BINARIES_CACHE% -DOPENCV_ENABLE_NONFREE=ON -DCMAKE_BUILD_TYPE=Release -DWITH_OPENCL=OFF -DWITH_VULKAN=ON'
   OPENCV_TEST_DATA_PATH: ${{ github.workspace }}\opencv_extra\testdata
+  OPENCV_TEST_REQUIRE_DATA: 1
   PR_AUTHOR: ${{ github.event.pull_request.user.login }}
   PR_AUTHOR_FORK: ${{ github.event.pull_request.head.repo.full_name }}
   SOURCE_BRANCH_NAME: ${{ github.head_ref }}

--- a/.github/workflows/OCV-PR-4.x-W10.yaml
+++ b/.github/workflows/OCV-PR-4.x-W10.yaml
@@ -15,6 +15,7 @@ concurrency:
 env:
   EXTRA_CMAKE_OPTIONS: '-DCL_Z_OPTION=/Z7 -DOPENCV_DOWNLOAD_PATH=%BINARIES_CACHE% -DBUILD_EXAMPLES=ON -DOPENCV_ENABLE_NONFREE=ON -DCMAKE_BUILD_TYPE=Release'
   OPENCV_TEST_DATA_PATH: ${{ github.workspace }}\opencv_extra\testdata
+  OPENCV_TEST_REQUIRE_DATA: 1
   PR_AUTHOR: ${{ github.event.pull_request.user.login }}
   PR_AUTHOR_FORK: ${{ github.event.pull_request.head.repo.full_name }}
   SOURCE_BRANCH_NAME: ${{ github.head_ref }}

--- a/.github/workflows/OCV-PR-4.x-macOS-ARM64-Vulkan.yaml
+++ b/.github/workflows/OCV-PR-4.x-macOS-ARM64-Vulkan.yaml
@@ -21,6 +21,7 @@ env:
   ANT_HOME: '/usr/share/ant'
   PYTHONPATH: '${{ github.workspace }}/build/python_loader:$PYTHONPATH'
   OPENCV_TEST_DATA_PATH: '${{ github.workspace }}/opencv_extra/testdata'
+  OPENCV_TEST_REQUIRE_DATA: 1
   GTEST_FILTER_STRING: '-GOTURN.memory_usage:DaSiamRPN.memory_usage:videoio_dynamic.basic_write:videoio/videocapture_acceleration.read/64:videoio/videocapture_acceleration.read/65:videoio/videocapture_acceleration.read/66:videoio/videocapture_acceleration.read/67'
   OPENCV_VULKAN_RUNTIME: '/opt/VulkanSDK/1.3.239.0/MoltenVK/dylib/macOS/libMoltenVK.dylib'
 

--- a/.github/workflows/OCV-PR-4.x-macOS-ARM64.yaml
+++ b/.github/workflows/OCV-PR-4.x-macOS-ARM64.yaml
@@ -21,6 +21,7 @@ env:
   ANT_HOME: '/usr/share/ant'
   PYTHONPATH: '${{ github.workspace }}/build/python_loader:$PYTHONPATH'
   OPENCV_TEST_DATA_PATH: '${{ github.workspace }}/opencv_extra/testdata'
+  OPENCV_TEST_REQUIRE_DATA: 1
   GTEST_FILTER_STRING: '-GOTURN.memory_usage:DaSiamRPN.memory_usage:videoio_dynamic.basic_write:videoio/videocapture_acceleration.read/64:videoio/videocapture_acceleration.read/65:videoio/videocapture_acceleration.read/66:videoio/videocapture_acceleration.read/67'
 
 jobs:

--- a/.github/workflows/OCV-PR-4.x-macOS-x86_64.yaml
+++ b/.github/workflows/OCV-PR-4.x-macOS-x86_64.yaml
@@ -21,6 +21,7 @@ env:
   ANT_HOME: '/usr/share/ant'
   PYTHONPATH: '${{ github.workspace }}/build/python_loader:$PYTHONPATH'
   OPENCV_TEST_DATA_PATH: '${{ github.workspace }}/opencv_extra/testdata'
+  OPENCV_TEST_REQUIRE_DATA: 1
 
 jobs:
   BuildAndTest:


### PR DESCRIPTION
Documentation: https://docs.opencv.org/4.x/d6/dea/tutorial_env_reference.html

Issue example:
```
[ RUN      ] Test_ONNX_nets.YOLONas/0, where GetParam() = OCV/CPU
[     SKIP ] OpenCV tests: Can't find data file: dnn/onnx/models/yolo_nas_s.onnx
[       OK ] Test_ONNX_nets.YOLONas/0 (0 ms)
```
CI: https://github.com/opencv/opencv/actions/runs/7395727245/job/20119459301?pr=24809