### PR TITLE
Increase timeout for MacOS Intel builds in contrib

### DIFF
--- a/.github/workflows/OCV-Contrib-PR-4.x-macOS-x86_64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-4.x-macOS-x86_64.yaml
@@ -117,7 +117,7 @@ jobs:
         cmake -B build -G Ninja ${{ env.EXTRA_CMAKE_OPTIONS }} -DOPENCV_EXTRA_MODULES_PATH=opencv_contrib/modules opencv
       working-directory: ${{ github.workspace }}
     - name: Build OpenCV
-      timeout-minutes: 60
+      timeout-minutes: 100
       id: build-opencv-contrib
       run: |
         ninja -j $PARALLEL_JOBS | tee ${{ github.workspace }}/build/build-log.txt

--- a/.github/workflows/OCV-Contrib-PR-5.x-macOS-x86_64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-5.x-macOS-x86_64.yaml
@@ -116,7 +116,7 @@ jobs:
         cmake -B build -G Ninja ${{ env.EXTRA_CMAKE_OPTIONS }} -DOPENCV_EXTRA_MODULES_PATH=opencv_contrib/modules opencv
       working-directory: ${{ github.workspace }}
     - name: Build OpenCV
-      timeout-minutes: 60
+      timeout-minutes: 100
       id: build-opencv-contrib
       run: |
         ninja -j $PARALLEL_JOBS | tee ${{ github.workspace }}/build/build-log.txt


### PR DESCRIPTION
Build is killed by timeout sometimes.
Example: https://github.com/opencv/opencv_contrib/actions/runs/8108486330/job/22161791260?pr=3642