### PR TITLE
Increase build timeout for OCV-PR-5.x-macOS-x86_64.yaml

### DIFF
--- a/.github/workflows/OCV-PR-5.x-macOS-x86_64.yaml
+++ b/.github/workflows/OCV-PR-5.x-macOS-x86_64.yaml
@@ -102,7 +102,7 @@ jobs:
         cmake -B build -G Ninja ${{ env.EXTRA_CMAKE_OPTIONS }} opencv
       working-directory: ${{ github.workspace }}
     - name: Build OpenCV
-      timeout-minutes: 60
+      timeout-minutes: 100
       id: build-opencv
       run: |
         ninja -j $PARALLEL_JOBS | tee ${{ github.workspace }}/build/build-log.txt
@@ -337,7 +337,7 @@ jobs:
         cmake -B build -G Ninja ${{ env.EXTRA_CMAKE_OPTIONS }} -DOPENCV_EXTRA_MODULES_PATH=opencv_contrib/modules opencv
       working-directory: ${{ github.workspace }}
     - name: Build OpenCV Contrib
-      timeout-minutes: 60
+      timeout-minutes: 100
       run: |
         ninja -j $PARALLEL_JOBS | tee ${{ github.workspace }}/build/build-log.txt
       working-directory: ${{ github.workspace }}/build


### PR DESCRIPTION
same as https://github.com/opencv/ci-gha-workflow/pull/160

resolves https://github.com/opencv/opencv/actions/runs/8244911397/job/22563065173

required for https://github.com/opencv/opencv/pull/25197