### PR TITLE
Replace deprecated uses: actions/upload-artifact@v3 with v4.

### DIFF
--- a/.github/workflows/OCV-4.x-Android-SDK.yaml
+++ b/.github/workflows/OCV-4.x-Android-SDK.yaml
@@ -120,7 +120,7 @@ jobs:
           zip -r -9 -y python-maven-repo.zip maven_repo
       - name: Release Package
         timeout-minutes: 60
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || env.RUNNER_DEBUG == 1 }}
         with:
           name: OpenCV4AndroidSDK

--- a/.github/workflows/OCV-Contrib-PR-3.4-ARM64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-3.4-ARM64.yaml
@@ -376,7 +376,7 @@ jobs:
       run: cd $HOME/build && xvfb-run -a python3 $HOME/opencv/modules/ts/misc/run.py . -a -t java
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
       with:
         name: junit-html-ubuntu20-arm64

--- a/.github/workflows/OCV-Contrib-PR-3.4-U14.yaml
+++ b/.github/workflows/OCV-Contrib-PR-3.4-U14.yaml
@@ -377,7 +377,7 @@ jobs:
       run: cd $HOME/build && xvfb-run -a python3 $HOME/opencv/modules/ts/misc/run.py . -a -t java
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
       with:
         name: junit-html-ubuntu14-x86-64

--- a/.github/workflows/OCV-Contrib-PR-3.4-U20.yaml
+++ b/.github/workflows/OCV-Contrib-PR-3.4-U20.yaml
@@ -376,7 +376,7 @@ jobs:
       run: cd $HOME/build && xvfb-run -a python3 $HOME/opencv/modules/ts/misc/run.py . -a -t java
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
       with:
         name: junit-html-ubuntu20-x86-64

--- a/.github/workflows/OCV-Contrib-PR-3.4-W10.yaml
+++ b/.github/workflows/OCV-Contrib-PR-3.4-W10.yaml
@@ -371,7 +371,7 @@ jobs:
         ${{ github.workspace }}\opencv\modules\ts\misc\run.py . -a -t java
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
       with:
         name: junit-html-windows10

--- a/.github/workflows/OCV-Contrib-PR-3.4-macOS-ARM64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-3.4-macOS-ARM64.yaml
@@ -427,7 +427,7 @@ jobs:
       working-directory: ${{ github.workspace }}/build
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
       with:
         name: junit-html-macos-arm64

--- a/.github/workflows/OCV-Contrib-PR-3.4-macOS-x86_64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-3.4-macOS-x86_64.yaml
@@ -427,7 +427,7 @@ jobs:
       working-directory: ${{ github.workspace }}/build
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
       with:
         name: junit-html-macos-x86-64

--- a/.github/workflows/OCV-Contrib-PR-4.x-ARM64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-4.x-ARM64.yaml
@@ -438,7 +438,7 @@ jobs:
       run: cd $HOME/build && xvfb-run -a python3 $HOME/opencv/modules/ts/misc/run.py . -a -t java
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
       with:
         name: junit-html-ubuntu20-arm64

--- a/.github/workflows/OCV-Contrib-PR-4.x-U20.yaml
+++ b/.github/workflows/OCV-Contrib-PR-4.x-U20.yaml
@@ -446,7 +446,7 @@ jobs:
       run: cd $HOME/build && xvfb-run -a python3 $HOME/opencv/modules/ts/misc/run.py . -a -t java
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
       with:
         name: junit-html-ubuntu20-x86-64

--- a/.github/workflows/OCV-Contrib-PR-4.x-U22.yaml
+++ b/.github/workflows/OCV-Contrib-PR-4.x-U22.yaml
@@ -449,7 +449,7 @@ jobs:
       run: cd $HOME/build && xvfb-run -a python3 $HOME/opencv/modules/ts/misc/run.py . -a -t java
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
       with:
         name: junit-html-ubuntu22-x86-64

--- a/.github/workflows/OCV-Contrib-PR-4.x-W10.yaml
+++ b/.github/workflows/OCV-Contrib-PR-4.x-W10.yaml
@@ -426,7 +426,7 @@ jobs:
         ${{ github.workspace }}\opencv\modules\ts\misc\run.py . -a -t java
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
       with:
         name: junit-html-windows10

--- a/.github/workflows/OCV-Contrib-PR-4.x-macOS-ARM64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-4.x-macOS-ARM64.yaml
@@ -500,7 +500,7 @@ jobs:
       working-directory: ${{ github.workspace }}/build
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
       with:
         name: junit-html-macos-arm64

--- a/.github/workflows/OCV-Contrib-PR-4.x-macOS-x86_64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-4.x-macOS-x86_64.yaml
@@ -501,7 +501,7 @@ jobs:
       working-directory: ${{ github.workspace }}/build
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
       with:
         name: junit-html-macos-x86-64

--- a/.github/workflows/OCV-Contrib-PR-5.x-ARM64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-5.x-ARM64.yaml
@@ -440,7 +440,7 @@ jobs:
       run: cd $HOME/build && xvfb-run -a python3 $HOME/opencv/modules/ts/misc/run.py . -a -t java
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
       with:
         name: junit-html-ubuntu20-arm64

--- a/.github/workflows/OCV-Contrib-PR-5.x-U20.yaml
+++ b/.github/workflows/OCV-Contrib-PR-5.x-U20.yaml
@@ -451,7 +451,7 @@ jobs:
       run: cd $HOME/build && xvfb-run -a python3 $HOME/opencv/modules/ts/misc/run.py . -a -t java
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
       with:
         name: junit-html-ubuntu20-x86-64

--- a/.github/workflows/OCV-Contrib-PR-5.x-U22.yaml
+++ b/.github/workflows/OCV-Contrib-PR-5.x-U22.yaml
@@ -454,7 +454,7 @@ jobs:
       run: cd $HOME/build && xvfb-run -a python3 $HOME/opencv/modules/ts/misc/run.py . -a -t java
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
       with:
         name: junit-html-ubuntu22-x86-64

--- a/.github/workflows/OCV-Contrib-PR-5.x-W10.yaml
+++ b/.github/workflows/OCV-Contrib-PR-5.x-W10.yaml
@@ -435,7 +435,7 @@ jobs:
         ${{ github.workspace }}\opencv\modules\ts\misc\run.py . -a -t java
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
       with:
         name: junit-html-windows10

--- a/.github/workflows/OCV-Contrib-PR-5.x-macOS-ARM64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-5.x-macOS-ARM64.yaml
@@ -507,7 +507,7 @@ jobs:
       working-directory: ${{ github.workspace }}/build
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
       with:
         name: junit-html-macos-arm64

--- a/.github/workflows/OCV-Contrib-PR-5.x-macOS-x86_64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-5.x-macOS-x86_64.yaml
@@ -510,7 +510,7 @@ jobs:
       working-directory: ${{ github.workspace }}/build
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
       with:
         name: junit-html-macos-x86-64

--- a/.github/workflows/OCV-Contrib-WinPack-4.x-W10.yaml
+++ b/.github/workflows/OCV-Contrib-WinPack-4.x-W10.yaml
@@ -200,7 +200,7 @@ jobs:
         %CI_SCRIPTS%\winpack_create.cmd
     - name: Save WinPack
       timeout-minutes: 60
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: WinPack
         path: artifacts\distrib.7z.exe

--- a/.github/workflows/OCV-Coverage-4.x-U20.yaml
+++ b/.github/workflows/OCV-Coverage-4.x-U20.yaml
@@ -179,7 +179,7 @@ jobs:
       run: cd /home/ci/build && xvfb-run -a python3 ${{ env.OPENCV_DOCKER_WORKDIR }}/modules/ts/misc/run.py . -a -t java --test_threads=2 --test_tag_skip=size_hd
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
       with:
         name: junit-html
@@ -205,7 +205,7 @@ jobs:
         genhtml --prefix /home/ci -t "OpenCV: ${{ env.TARGET_BRANCH_NAME }}-$GITHUB_SHA" -o /home/ci/build/test_coverage_html /home/ci/build/opencv_test_filtered.info
     - name: Upload test coverage
       timeout-minutes: 60
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: ${{ always() && steps.coverage-test-report.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
       with:
         name: test-coverage-html
@@ -291,7 +291,7 @@ jobs:
         genhtml --prefix /home/ci -t "OpenCV: ${{ env.TARGET_BRANCH_NAME }}-$GITHUB_SHA" -o /home/ci/build/perf_coverage_html /home/ci/build/opencv_perf_filtered.info
     - name: Upload perf coverage
       timeout-minutes: 60
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: ${{ always() && steps.coverage-perf-report.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
       with:
         name: perf-coverage-html

--- a/.github/workflows/OCV-Nightly-docs-js.yaml
+++ b/.github/workflows/OCV-Nightly-docs-js.yaml
@@ -69,7 +69,7 @@ jobs:
     - name: Upload arftifacts
       timeout-minutes: 60
       if: ${{ (always() && steps.build-opencv.outcome == 'success') && github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || env.RUNNER_DEBUG == 1 }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: OpenCVDocDoxygen${{ matrix.branch }}
         path: /home/ci/build/release/doc_doxygen.zip

--- a/.github/workflows/OCV-PR-3.4-ARM64.yaml
+++ b/.github/workflows/OCV-PR-3.4-ARM64.yaml
@@ -243,7 +243,7 @@ jobs:
       run: cd $HOME/build && xvfb-run -a python3 ${{ env.OPENCV_DOCKER_WORKDIR }}/modules/ts/misc/run.py . -a -t java
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
       with:
         name: junit-html-ubuntu20-arm64

--- a/.github/workflows/OCV-PR-3.4-Android.yaml
+++ b/.github/workflows/OCV-PR-3.4-Android.yaml
@@ -89,7 +89,7 @@ jobs:
         run: cd /home/ci/build && zip -r -9 -y OpenCV3Android.zip OpenCV-android-sdk
       - name: Release Package
         timeout-minutes: 60
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || env.RUNNER_DEBUG == 1 }}
         with:
           name: OpenCV3AndroidSDK

--- a/.github/workflows/OCV-PR-3.4-U14.yaml
+++ b/.github/workflows/OCV-PR-3.4-U14.yaml
@@ -245,7 +245,7 @@ jobs:
       run: cd $HOME/build && xvfb-run -a python3 ${{ env.OPENCV_DOCKER_WORKDIR }}/modules/ts/misc/run.py . -a -t java
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
       with:
         name: junit-html-ubuntu14-x86-64

--- a/.github/workflows/OCV-PR-3.4-U20.yaml
+++ b/.github/workflows/OCV-PR-3.4-U20.yaml
@@ -244,7 +244,7 @@ jobs:
       run: cd $HOME/build && xvfb-run -a python3 ${{ env.OPENCV_DOCKER_WORKDIR }}/modules/ts/misc/run.py . -a -t java
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
       with:
         name: junit-html-ubuntu20-x86-64

--- a/.github/workflows/OCV-PR-3.4-W10.yaml
+++ b/.github/workflows/OCV-PR-3.4-W10.yaml
@@ -247,7 +247,7 @@ jobs:
         ${{ github.workspace }}\opencv\modules\ts\misc\run.py . -a -t java
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
       with:
         name: junit-html-windows10

--- a/.github/workflows/OCV-PR-3.4-iOS.yaml
+++ b/.github/workflows/OCV-PR-3.4-iOS.yaml
@@ -61,7 +61,7 @@ jobs:
         run: cd ${{ github.workspace }}/ios && zip -r -9 -y opencv-3.4-ios-framework.zip opencv2.framework
       - name: Upload Artifact
         timeout-minutes: 60
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || env.RUNNER_DEBUG == 1 }}
         with:
           name: OpenCViOSFramework

--- a/.github/workflows/OCV-PR-3.4-macOS-ARM64.yaml
+++ b/.github/workflows/OCV-PR-3.4-macOS-ARM64.yaml
@@ -265,7 +265,7 @@ jobs:
       working-directory: ${{ github.workspace }}/build
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
       with:
         name: junit-html-macos-arm64

--- a/.github/workflows/OCV-PR-3.4-macOS-x86_64.yaml
+++ b/.github/workflows/OCV-PR-3.4-macOS-x86_64.yaml
@@ -265,7 +265,7 @@ jobs:
       working-directory: ${{ github.workspace }}/build
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
       with:
         name: junit-html-macos-x86-64

--- a/.github/workflows/OCV-PR-4.x-ARM64-Debug.yaml
+++ b/.github/workflows/OCV-PR-4.x-ARM64-Debug.yaml
@@ -193,7 +193,7 @@ jobs:
       run: cd $HOME/build && xvfb-run -a python3 ${{ env.OPENCV_DOCKER_WORKDIR }}/modules/ts/misc/run.py . -a -t java
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
       with:
         name: junit-html-ubuntu20-arm64

--- a/.github/workflows/OCV-PR-4.x-ARM64.yaml
+++ b/.github/workflows/OCV-PR-4.x-ARM64.yaml
@@ -241,7 +241,7 @@ jobs:
       run: cd $HOME/build && xvfb-run -a python3 ${{ env.OPENCV_DOCKER_WORKDIR }}/modules/ts/misc/run.py . -a -t java
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
       with:
         name: junit-html-ubuntu20-arm64

--- a/.github/workflows/OCV-PR-4.x-U20.yaml
+++ b/.github/workflows/OCV-PR-4.x-U20.yaml
@@ -250,7 +250,7 @@ jobs:
       run: cd $HOME/build && xvfb-run -a python3 ${{ env.OPENCV_DOCKER_WORKDIR }}/modules/ts/misc/run.py . -a -t java
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
       with:
         name: junit-html-ubuntu20-x86-64

--- a/.github/workflows/OCV-PR-4.x-U22.yaml
+++ b/.github/workflows/OCV-PR-4.x-U22.yaml
@@ -253,7 +253,7 @@ jobs:
       run: cd $HOME/build && xvfb-run -a python3 ${{ env.OPENCV_DOCKER_WORKDIR }}/modules/ts/misc/run.py . -a -t java
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
       with:
         name: junit-html-ubuntu22-x86-64

--- a/.github/workflows/OCV-PR-4.x-W10-Vulkan.yaml
+++ b/.github/workflows/OCV-PR-4.x-W10-Vulkan.yaml
@@ -124,7 +124,7 @@ jobs:
     #   run: cd ${{ github.workspace }}\build && bin\opencv_perf_dnn.exe --perf_impl=plain --perf_min_samples=1 --perf_force_samples=1 --perf_verify_sanity --skip_unstable=1 --gtest_filter=${{ env.GTEST_FILTER_STRING }} --perf_threads=%PARALLEL_JOBS%
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
       with:
         name: junit-html-windows10

--- a/.github/workflows/OCV-PR-4.x-W10.yaml
+++ b/.github/workflows/OCV-PR-4.x-W10.yaml
@@ -240,7 +240,7 @@ jobs:
         ${{ github.workspace }}\opencv\modules\ts\misc\run.py . -a -t java
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
       with:
         name: junit-html-windows10

--- a/.github/workflows/OCV-PR-4.x-iOS.yaml
+++ b/.github/workflows/OCV-PR-4.x-iOS.yaml
@@ -61,7 +61,7 @@ jobs:
         run: cd ${{ github.workspace }}/ios && zip -r -9 -y opencv-4.x-ios-framework.zip opencv2.framework
       - name: Upload Artifact
         timeout-minutes: 60
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || env.RUNNER_DEBUG == 1 }}
         with:
           name: OpenCViOSFramework

--- a/.github/workflows/OCV-PR-4.x-loongnix-loongarch64.yaml
+++ b/.github/workflows/OCV-PR-4.x-loongnix-loongarch64.yaml
@@ -260,7 +260,7 @@ jobs:
         working-directory: ${{ github.workspace }}/build
       - name: Save Unit Test Results
         timeout-minutes: 60
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' && steps.check-warnings.outcome == 'success' }}
         with:
           name: junit-html-macos-arm64

--- a/.github/workflows/OCV-PR-4.x-macOS-ARM64-Vulkan.yaml
+++ b/.github/workflows/OCV-PR-4.x-macOS-ARM64-Vulkan.yaml
@@ -125,7 +125,7 @@ jobs:
       working-directory: ${{ github.workspace }}/build
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
       with:
         name: junit-html-macos-arm64

--- a/.github/workflows/OCV-PR-4.x-macOS-ARM64.yaml
+++ b/.github/workflows/OCV-PR-4.x-macOS-ARM64.yaml
@@ -260,7 +260,7 @@ jobs:
       working-directory: ${{ github.workspace }}/build
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
       with:
         name: junit-html-macos-arm64

--- a/.github/workflows/OCV-PR-4.x-macOS-x86_64.yaml
+++ b/.github/workflows/OCV-PR-4.x-macOS-x86_64.yaml
@@ -261,7 +261,7 @@ jobs:
       working-directory: ${{ github.workspace }}/build
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
       with:
         name: junit-html-macos-x86-64

--- a/.github/workflows/OCV-PR-5.x-ARM64-Debug.yaml
+++ b/.github/workflows/OCV-PR-5.x-ARM64-Debug.yaml
@@ -196,7 +196,7 @@ jobs:
       run: cd $HOME/build && xvfb-run -a python3 ${{ env.OPENCV_DOCKER_WORKDIR }}/modules/ts/misc/run.py . -a -t java
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
       with:
         name: junit-html-ubuntu20-arm64

--- a/.github/workflows/OCV-PR-5.x-ARM64.yaml
+++ b/.github/workflows/OCV-PR-5.x-ARM64.yaml
@@ -253,7 +253,7 @@ jobs:
       run: cd $HOME/build && xvfb-run -a python3 ${{ env.OPENCV_DOCKER_WORKDIR }}/modules/ts/misc/run.py . -a -t java
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
       with:
         name: junit-html-ubuntu20-arm64

--- a/.github/workflows/OCV-PR-5.x-Android.yaml
+++ b/.github/workflows/OCV-PR-5.x-Android.yaml
@@ -126,7 +126,7 @@ jobs:
           zip -r -9 -y python-maven-repo.zip maven_repo
       - name: Release Package
         timeout-minutes: 60
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || env.RUNNER_DEBUG == 1 }}
         with:
           name: OpenCV4AndroidSDK

--- a/.github/workflows/OCV-PR-5.x-U20.yaml
+++ b/.github/workflows/OCV-PR-5.x-U20.yaml
@@ -260,7 +260,7 @@ jobs:
       run: cd $HOME/build && xvfb-run -a python3 ${{ env.OPENCV_DOCKER_WORKDIR }}/modules/ts/misc/run.py . -a -t java
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
       with:
         name: junit-html-ubuntu20-x86-64

--- a/.github/workflows/OCV-PR-5.x-U22.yaml
+++ b/.github/workflows/OCV-PR-5.x-U22.yaml
@@ -263,7 +263,7 @@ jobs:
       run: cd $HOME/build && xvfb-run -a python3 ${{ env.OPENCV_DOCKER_WORKDIR }}/modules/ts/misc/run.py . -a -t java
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
       with:
         name: junit-html-ubuntu22-x86-64

--- a/.github/workflows/OCV-PR-5.x-W10.yaml
+++ b/.github/workflows/OCV-PR-5.x-W10.yaml
@@ -252,7 +252,7 @@ jobs:
         ${{ github.workspace }}\opencv\modules\ts\misc\run.py . -a -t java
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
       with:
         name: junit-html-windows10

--- a/.github/workflows/OCV-PR-5.x-iOS.yaml
+++ b/.github/workflows/OCV-PR-5.x-iOS.yaml
@@ -61,7 +61,7 @@ jobs:
         run: cd ${{ github.workspace }}/ios && zip -r -9 -y opencv-5.x-ios-framework.zip opencv2.framework
       - name: Upload Artifact
         timeout-minutes: 60
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || env.RUNNER_DEBUG == 1 }}
         with:
           name: OpenCViOSFramework

--- a/.github/workflows/OCV-PR-5.x-macOS-ARM64.yaml
+++ b/.github/workflows/OCV-PR-5.x-macOS-ARM64.yaml
@@ -275,7 +275,7 @@ jobs:
       working-directory: ${{ github.workspace }}/build
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
       with:
         name: junit-html-macos-arm64

--- a/.github/workflows/OCV-PR-5.x-macOS-x86_64.yaml
+++ b/.github/workflows/OCV-PR-5.x-macOS-x86_64.yaml
@@ -276,7 +276,7 @@ jobs:
       working-directory: ${{ github.workspace }}/build
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
       with:
         name: junit-html-macos-x86-64

--- a/.github/workflows/OCV-WinPack-4.x-W10.yaml
+++ b/.github/workflows/OCV-WinPack-4.x-W10.yaml
@@ -185,7 +185,7 @@ jobs:
         %CI_SCRIPTS%\winpack_create.cmd
     - name: Save WinPack
       timeout-minutes: 60
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: WinPack
         path: artifacts\distrib.7z.exe


### PR DESCRIPTION
Github actions warning example:

```
macOS-ARM64 / BuildAndTest
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/upload-artifact@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```