### PR TITLE
Switch to Android Build tools 34 and NDK 27.

### DIFF
--- a/.github/workflows/OCV-4.x-Android-SDK.yaml
+++ b/.github/workflows/OCV-4.x-Android-SDK.yaml
@@ -33,7 +33,7 @@ jobs:
       run:
         shell: bash
     container:
-      image: quay.io/opencv-ci/opencv-androidsdk-30:20240213
+      image: quay.io/opencv-ci/opencv-androidsdk-34:20240824
       volumes:
         - /home/opencv-cn/git_cache:/home/ci/git_cache
         - /home/opencv-cn/ci_cache/opencv:/home/ci/.ccache
@@ -79,7 +79,7 @@ jobs:
           mkdir -p /home/ci/build
           cd /home/ci/build
           sed -i 's+https\\://services.gradle.org/distributions/gradle-@GRADLE_VERSION@-all.zip+file\\:/opt/gradle/gradle-@GRADLE_VERSION@-bin.zip+g' ${{ env.OPENCV_DOCKER_WORKDIR }}/platforms/android/gradle-wrapper/gradle/wrapper/gradle-wrapper.properties.in
-          python3 "${{ env.OPENCV_DOCKER_WORKDIR }}/platforms/android/build_sdk.py" --build_doc --config "${{ env.OPENCV_DOCKER_WORKDIR }}/platforms/android/ndk-18-api-level-21.config.py" --sdk_path "$ANDROID_HOME" --ndk_path "$ANDROID_NDK_HOME" /home/ci/build | tee /home/ci/build/build-log.txt
+          python3 "${{ env.OPENCV_DOCKER_WORKDIR }}/platforms/android/build_sdk.py" --build_doc --config "${{ env.OPENCV_DOCKER_WORKDIR }}/platforms/android/default.config.py" --sdk_path "$ANDROID_HOME" --ndk_path "$ANDROID_NDK_HOME" /home/ci/build | tee /home/ci/build/build-log.txt
       - name: Warning check
         timeout-minutes: 60
         run: cd /home/ci/build && python3 /home/ci/scripts/warnings-handling.py


### PR DESCRIPTION
Requires https://github.com/opencv-infrastructure/opencv-gha-dockerfile/pull/41