### PR TITLE
Switch to Android Build tools 34 and NDK 26d.

### DIFF
--- a/.github/workflows/OCV-4.x-Android-SDK.yaml
+++ b/.github/workflows/OCV-4.x-Android-SDK.yaml
@@ -33,7 +33,7 @@ jobs:
       run:
         shell: bash
     container:
-      image: quay.io/opencv-ci/opencv-androidsdk-30:20240213
+      image: quay.io/opencv-ci/opencv-androidsdk-34:20240824
       volumes:
         - /home/opencv-cn/git_cache:/home/ci/git_cache
         - /home/opencv-cn/ci_cache/opencv:/home/ci/.ccache
@@ -79,7 +79,7 @@ jobs:
           mkdir -p /home/ci/build
           cd /home/ci/build
           sed -i 's+https\\://services.gradle.org/distributions/gradle-@GRADLE_VERSION@-all.zip+file\\:/opt/gradle/gradle-@GRADLE_VERSION@-bin.zip+g' ${{ env.OPENCV_DOCKER_WORKDIR }}/platforms/android/gradle-wrapper/gradle/wrapper/gradle-wrapper.properties.in
-          python3 "${{ env.OPENCV_DOCKER_WORKDIR }}/platforms/android/build_sdk.py" --build_doc --config "${{ env.OPENCV_DOCKER_WORKDIR }}/platforms/android/ndk-18-api-level-21.config.py" --sdk_path "$ANDROID_HOME" --ndk_path "$ANDROID_NDK_HOME" /home/ci/build | tee /home/ci/build/build-log.txt
+          python3 "${{ env.OPENCV_DOCKER_WORKDIR }}/platforms/android/build_sdk.py" --build_doc --config "${{ env.OPENCV_DOCKER_WORKDIR }}/platforms/android/default.config.py" --sdk_path "$ANDROID_HOME" --ndk_path "$ANDROID_NDK_HOME" /home/ci/build | tee /home/ci/build/build-log.txt
       - name: Warning check
         timeout-minutes: 60
         run: cd /home/ci/build && python3 /home/ci/scripts/warnings-handling.py

--- a/.github/workflows/OCV-4.x-Android-SDK.yaml
+++ b/.github/workflows/OCV-4.x-Android-SDK.yaml
@@ -90,13 +90,13 @@ jobs:
         timeout-minutes: 60
         run: |
           cd /home/ci/build
-          sed -i 's+https\\://services.gradle.org/distributions/gradle-7.6.3-bin.zip+file\\:/opt/gradle/gradle-7.6.3-bin.zip+g' ${{ env.OPENCV_DOCKER_WORKDIR }}/platforms/android/aar-template/gradle/wrapper/gradle-wrapper.properties
+          sed -i 's+https\\://services.gradle.org/distributions/gradle-8.10-bin.zip+file\\:/opt/gradle/gradle-8.10-bin.zip+g' ${{ env.OPENCV_DOCKER_WORKDIR }}/platforms/android/aar-template/gradle/wrapper/gradle-wrapper.properties
           python3 "${{ env.OPENCV_DOCKER_WORKDIR }}/platforms/android/build_java_shared_aar.py" --offline --ndk_location="$ANDROID_NDK_HOME" --cmake_location=$(dirname $(dirname $(which cmake))) /home/ci/build/OpenCV-android-sdk
       - name: Build Static AAR
         timeout-minutes: 60
         run: |
           cd /home/ci/build
-          sed -i 's+https\\://services.gradle.org/distributions/gradle-7.6.3-bin.zip+file\\:/opt/gradle/gradle-7.6.3-bin.zip+g' ${{ env.OPENCV_DOCKER_WORKDIR }}/platforms/android/aar-template/gradle/wrapper/gradle-wrapper.properties
+          sed -i 's+https\\://services.gradle.org/distributions/gradle-8.10-bin.zip+file\\:/opt/gradle/gradle-8.10-bin.zip+g' ${{ env.OPENCV_DOCKER_WORKDIR }}/platforms/android/aar-template/gradle/wrapper/gradle-wrapper.properties
           python3 "${{ env.OPENCV_DOCKER_WORKDIR }}/platforms/android/build_static_aar.py" --offline --ndk_location="$ANDROID_NDK_HOME" --cmake_location=$(dirname $(dirname $(which cmake))) /home/ci/build/OpenCV-android-sdk
       - name: Test CMake
         timeout-minutes: 60
@@ -114,7 +114,7 @@ jobs:
         run: |
           cd /home/ci/build
           # revert hacked Gradle URL to the original one
-          sed -i 's+file\\:/opt/gradle/gradle-7.6.3-bin.zip+https\\://services.gradle.org/distributions/gradle-7.6.3-bin.zip+g' OpenCV-android-sdk/samples/gradle/wrapper/gradle-wrapper.properties
+          sed -i 's+file\\:/opt/gradle/gradle-8.10-bin.zip+https\\://services.gradle.org/distributions/gradle-8.10-bin.zip+g' OpenCV-android-sdk/samples/gradle/wrapper/gradle-wrapper.properties
           zip -r -9 -y OpenCV4Android.zip OpenCV-android-sdk
           cd /home/ci/build/outputs
           zip -r -9 -y python-maven-repo.zip maven_repo

--- a/.github/workflows/OCV-4.x-Android-SDK.yaml
+++ b/.github/workflows/OCV-4.x-Android-SDK.yaml
@@ -33,7 +33,7 @@ jobs:
       run:
         shell: bash
     container:
-      image: quay.io/opencv-ci/opencv-androidsdk-34:20240824
+      image: quay.io/opencv-ci/opencv-androidsdk-34:20240917
       volumes:
         - /home/opencv-cn/git_cache:/home/ci/git_cache
         - /home/opencv-cn/ci_cache/opencv:/home/ci/.ccache
@@ -90,13 +90,13 @@ jobs:
         timeout-minutes: 60
         run: |
           cd /home/ci/build
-          sed -i 's+https\\://services.gradle.org/distributions/gradle-8.10-bin.zip+file\\:/opt/gradle/gradle-8.10-bin.zip+g' ${{ env.OPENCV_DOCKER_WORKDIR }}/platforms/android/aar-template/gradle/wrapper/gradle-wrapper.properties
+          sed -i 's+https\\://services.gradle.org/distributions/gradle-8.11.1-bin.zip+file\\:/opt/gradle/gradle-8.11.1-bin.zip+g' ${{ env.OPENCV_DOCKER_WORKDIR }}/platforms/android/aar-template/gradle/wrapper/gradle-wrapper.properties
           python3 "${{ env.OPENCV_DOCKER_WORKDIR }}/platforms/android/build_java_shared_aar.py" --offline --ndk_location="$ANDROID_NDK_HOME" --cmake_location=$(dirname $(dirname $(which cmake))) /home/ci/build/OpenCV-android-sdk
       - name: Build Static AAR
         timeout-minutes: 60
         run: |
           cd /home/ci/build
-          sed -i 's+https\\://services.gradle.org/distributions/gradle-8.10-bin.zip+file\\:/opt/gradle/gradle-8.10-bin.zip+g' ${{ env.OPENCV_DOCKER_WORKDIR }}/platforms/android/aar-template/gradle/wrapper/gradle-wrapper.properties
+          sed -i 's+https\\://services.gradle.org/distributions/gradle-8.11.1-bin.zip+file\\:/opt/gradle/gradle-8.11.1-bin.zip+g' ${{ env.OPENCV_DOCKER_WORKDIR }}/platforms/android/aar-template/gradle/wrapper/gradle-wrapper.properties
           python3 "${{ env.OPENCV_DOCKER_WORKDIR }}/platforms/android/build_static_aar.py" --offline --ndk_location="$ANDROID_NDK_HOME" --cmake_location=$(dirname $(dirname $(which cmake))) /home/ci/build/OpenCV-android-sdk
       - name: Test CMake
         timeout-minutes: 60
@@ -114,7 +114,7 @@ jobs:
         run: |
           cd /home/ci/build
           # revert hacked Gradle URL to the original one
-          sed -i 's+file\\:/opt/gradle/gradle-8.10-bin.zip+https\\://services.gradle.org/distributions/gradle-8.10-bin.zip+g' OpenCV-android-sdk/samples/gradle/wrapper/gradle-wrapper.properties
+          sed -i 's+file\\:/opt/gradle/gradle-8.11.1-bin.zip+https\\://services.gradle.org/distributions/gradle-8.11.1-bin.zip+g' OpenCV-android-sdk/samples/gradle/wrapper/gradle-wrapper.properties
           zip -r -9 -y OpenCV4Android.zip OpenCV-android-sdk
           cd /home/ci/build/outputs
           zip -r -9 -y python-maven-repo.zip maven_repo


### PR DESCRIPTION
Requires https://github.com/opencv-infrastructure/opencv-gha-dockerfile/pull/41
Requires https://github.com/opencv/opencv/pull/26057

Related issue: https://github.com/opencv/opencv/issues/26072