### PR TITLE
suppresses warnings that have already been emitted

### DIFF
--- a/scripts/warnings-handling.py
+++ b/scripts/warnings-handling.py
@@ -23,15 +23,17 @@ def warnings_count(filename, verbose):
     warnings = 0
     suppressed = 0
     total = 0
+    seen_warnings = []
     for line in open(filename):
         total += 1
         match = rx.search(line)
         if match:
             if is_suppressed(line):
                 suppressed += 1
-            else:
+            elif line not in seen_warnings:
                 print("***> {}".format(line.rstrip()))
                 warnings += 1
+                seen_warnings.append(line)
                 continue
         if verbose:
             print(line.rstrip())


### PR DESCRIPTION
Warnings generated in headers can be seen thousands of times, particularly for function templates (but only one instance of the warning is actually helpful). This commit suppresses subsequent occurrences to keep the list of useful warnings readable.