### PR TITLE
Fixed name collision in upload artifacts

### DIFF
--- a/.github/workflows/OCV-PR-4.x-ARM64-Debug.yaml
+++ b/.github/workflows/OCV-PR-4.x-ARM64-Debug.yaml
@@ -197,7 +197,7 @@ jobs:
       uses: actions/upload-artifact@v4
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
       with:
-        name: junit-html-ubuntu20-arm64
+        name: junit-html-ubuntu20-arm64-debug
         path: /home/ci/build/java_test/testResults/junit-noframes.html
 
   BuildContrib:


### PR DESCRIPTION
Fixes
```
/usr/bin/docker exec  9a73f4e46ebdf1bc51ec67674734e30ea266abfdf19d783f14ff43c9e22b9ac5 sh -c "cat /etc/*release | grep ^ID"
With the provided path, there will be 1 file uploaded
Artifact name is valid!
Root directory input is valid!
Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run
```