### PR TITLE
Docker update to cover OpenEXR branch.

### DIFF
--- a/.github/workflows/OCV-PR-Linux.yaml
+++ b/.github/workflows/OCV-PR-Linux.yaml
@@ -61,13 +61,13 @@ jobs:
         branch: ${{ fromJSON(needs.branch_eval.outputs.branches )}}
         include:
           - version: '24.04'
-            image: '24.04:20250329'
+            image: '24.04:20250505'
             jpegxl: true
             avif: true
             avx2: true
           # TODO: enable later
           # - version: '24.04_asan'
-          #   image: '24.04:20250329'
+          #   image: '24.04:20250505'
           #   asan: true
           #   jpegxl: true
           #   avif: true
@@ -76,7 +76,7 @@ jobs:
             avif: true
             plugins: true
           - version: '20.04'
-            image: '20.04:20230413'
+            image: '20.04:20250505'
             limited_api: true
 
     defaults:

--- a/docker/ubuntu/Dockerfile-20
+++ b/docker/ubuntu/Dockerfile-20
@@ -1,4 +1,4 @@
-# Version: 20230413
+# Version: 20250505
 # Image name: quay.io/opencv-ci/opencv-ubuntu-20.04
 
 FROM ubuntu:20.04
@@ -35,6 +35,7 @@ RUN \
     libtiff5-dev \
     libopenjp2-7-dev \
     libraw-dev \
+    libopenexr-dev \
     libgtk-3-dev \
     libavcodec-dev \
     libavformat-dev \
@@ -67,7 +68,7 @@ RUN \
     pkg-config \
     && \
   apt-get clean && python3 -m pip install --upgrade pip && \
-  pip install requests pylint==2.4.4 reportlab svglib && pip cache purge
+  pip install requests pylint==2.4.4 reportlab svglib pycairo rlPyCairo && pip cache purge
 
 RUN \
   apt-get update && \

--- a/docker/ubuntu/Dockerfile-24
+++ b/docker/ubuntu/Dockerfile-24
@@ -1,4 +1,4 @@
-# Version: 20250329
+# Version: 20250505
 # Image name: quay.io/opencv-ci/opencv-ubuntu-24.04
 
 FROM ubuntu:24.04
@@ -40,6 +40,7 @@ RUN \
     libopenjp2-7-dev \
     libavif-dev \
     libjxl-dev \
+    libopenexr-dev \
     libgtk-3-dev \
     libgtk-4-dev \
     libavcodec-dev \


### PR DESCRIPTION
Requires https://github.com/opencv-infrastructure/opencv-gha-dockerfile/pull/48
Ubuntu 22.04 is not touched to cover the case without OpenEXR.