### PR TITLE
4.x: Update videoio test filters for Win and OSX

### DIFF
--- a/.github/workflows/OCV-Contrib-PR-4.x-W10.yaml
+++ b/.github/workflows/OCV-Contrib-PR-4.x-W10.yaml
@@ -20,7 +20,7 @@ env:
   TARGET_BRANCH_NAME: ${{ github.base_ref }}
   OPENCV_TEST_DATA_PATH: ${{ github.workspace }}\opencv_extra\testdata
   OPENCV_TEST_REQUIRE_DATA: 1
-  GTEST_FILTER_STRING: '-Samples.findFile:videoio/videocapture_acceleration.read/122:videoio/videocapture_acceleration.read/126:videoio/videocapture_acceleration.read/136'
+  GTEST_FILTER_STRING: '-Samples.findFile:videoio/videocapture_acceleration.read/yuv420p_libvpxxvp9_mp4_MSMF_NONE_MAT'
   DOWNLOAD_DNN_MODELS_FILE: 'download_models.py'
 
 jobs:

--- a/.github/workflows/OCV-Contrib-PR-4.x-macOS-ARM64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-4.x-macOS-ARM64.yaml
@@ -22,7 +22,7 @@ env:
   PYTHONPATH: '${{ github.workspace }}/build/python_loader:$PYTHONPATH'
   OPENCV_TEST_DATA_PATH: '${{ github.workspace }}/opencv_extra/testdata'
   OPENCV_TEST_REQUIRE_DATA: 1
-  GTEST_FILTER_STRING: '-GOTURN.memory_usage:DaSiamRPN.memory_usage:videoio_dynamic.basic_write:Tracking_Boosting.Boosting/0:Tracking_Boosting.Boosting/1:Tracking_Boosting.Boosting/2:Tracking_TLD.TLD/0:Tracking_TLD.TLD/1:Tracking_TLD.TLD/2:Tracking/DistanceAndOverlap.TLD/2:Tracking/DistanceAndOverlap.Scaled_Data_TLD/2:videoio/videocapture_acceleration.read/64:videoio/videocapture_acceleration.read/65:videoio/videocapture_acceleration.read/66:videoio/videocapture_acceleration.read/67'
+  GTEST_FILTER_STRING: '-GOTURN.memory_usage:DaSiamRPN.memory_usage:videoio_dynamic.basic_write:Tracking_Boosting.Boosting/0:Tracking_Boosting.Boosting/1:Tracking_Boosting.Boosting/2:Tracking_TLD.TLD/0:Tracking_TLD.TLD/1:Tracking_TLD.TLD/2:Tracking/DistanceAndOverlap.TLD/2:Tracking/DistanceAndOverlap.Scaled_Data_TLD/2:videoio/videocapture_acceleration.read/yuv420p_libx265_mp4_FFMPEG_*'
 
 jobs:
   BuildAndTest:

--- a/.github/workflows/OCV-PR-4.x-W10-Vulkan.yaml
+++ b/.github/workflows/OCV-PR-4.x-W10-Vulkan.yaml
@@ -21,7 +21,7 @@ env:
   PR_AUTHOR_FORK: ${{ github.event.pull_request.head.repo.full_name }}
   SOURCE_BRANCH_NAME: ${{ github.head_ref }}
   TARGET_BRANCH_NAME: ${{ github.base_ref }}
-  GTEST_FILTER_STRING: '-Samples.findFile:videoio/videocapture_acceleration.read/122:videoio/videocapture_acceleration.read/126'
+  GTEST_FILTER_STRING: '-Samples.findFile:videoio/videocapture_acceleration.read/yuv420p_libvpxxvp9_mp4_MSMF_NONE_MAT'
   DOWNLOAD_DNN_MODELS_FILE: 'download_models.py'
   OPENCV_VULKAN_RUNTIME: 'C:\VulkanSDK\1.3.239.0\Bin\vulkan-1.dll'
 

--- a/.github/workflows/OCV-PR-4.x-W10.yaml
+++ b/.github/workflows/OCV-PR-4.x-W10.yaml
@@ -25,7 +25,7 @@ env:
   PR_AUTHOR_FORK: ${{ github.event.pull_request.head.repo.full_name }}
   SOURCE_BRANCH_NAME: ${{ github.head_ref }}
   TARGET_BRANCH_NAME: ${{ github.base_ref }}
-  GTEST_FILTER_STRING: '-Samples.findFile:videoio/videocapture_acceleration.read/122:videoio/videocapture_acceleration.read/126:videoio/videocapture_acceleration.read/136'
+  GTEST_FILTER_STRING: '-Samples.findFile:videoio/videocapture_acceleration.read/yuv420p_libvpxxvp9_mp4_MSMF_NONE_MAT'
   DOWNLOAD_DNN_MODELS_FILE: 'download_models.py'
 
 jobs:

--- a/.github/workflows/OCV-PR-4.x-loongnix-loongarch64.yaml
+++ b/.github/workflows/OCV-PR-4.x-loongnix-loongarch64.yaml
@@ -21,7 +21,6 @@ env:
   ANT_HOME: '/usr/share/ant'
   PYTHONPATH: '${{ github.workspace }}/build/python_loader:$PYTHONPATH'
   OPENCV_TEST_DATA_PATH: '${{ github.workspace }}/opencv_extra/testdata'
-  # GTEST_FILTER_STRING: '-GOTURN.memory_usage:DaSiamRPN.memory_usage:videoio_dynamic.basic_write:videoio/videocapture_acceleration.read/64:videoio/videocapture_acceleration.read/65:videoio/videocapture_acceleration.read/66:videoio/videocapture_acceleration.read/67'
 
 jobs:
   BuildAndTest:

--- a/.github/workflows/OCV-PR-4.x-macOS-ARM64-Vulkan.yaml
+++ b/.github/workflows/OCV-PR-4.x-macOS-ARM64-Vulkan.yaml
@@ -22,7 +22,7 @@ env:
   PYTHONPATH: '${{ github.workspace }}/build/python_loader:$PYTHONPATH'
   OPENCV_TEST_DATA_PATH: '${{ github.workspace }}/opencv_extra/testdata'
   OPENCV_TEST_REQUIRE_DATA: 1
-  GTEST_FILTER_STRING: '-GOTURN.memory_usage:DaSiamRPN.memory_usage:videoio_dynamic.basic_write:videoio/videocapture_acceleration.read/64:videoio/videocapture_acceleration.read/65:videoio/videocapture_acceleration.read/66:videoio/videocapture_acceleration.read/67'
+  GTEST_FILTER_STRING: '-GOTURN.memory_usage:DaSiamRPN.memory_usage:videoio_dynamic.basic_write:videoio/videocapture_acceleration.read/yuv420p_libx265_mp4_FFMPEG_*'
   OPENCV_VULKAN_RUNTIME: '/opt/VulkanSDK/1.3.239.0/MoltenVK/dylib/macOS/libMoltenVK.dylib'
 
 jobs:

--- a/.github/workflows/OCV-PR-4.x-macOS-ARM64.yaml
+++ b/.github/workflows/OCV-PR-4.x-macOS-ARM64.yaml
@@ -23,7 +23,7 @@ env:
   OPENCV_TEST_DATA_PATH: '${{ github.workspace }}/opencv_extra/testdata'
   OPENCV_TEST_REQUIRE_DATA: 1
   OPENCV_TEST_CHECK_OPTIONAL_DATA: 1
-  GTEST_FILTER_STRING: '-GOTURN.memory_usage:DaSiamRPN.memory_usage:videoio_dynamic.basic_write:videoio/videocapture_acceleration.read/64:videoio/videocapture_acceleration.read/65:videoio/videocapture_acceleration.read/66:videoio/videocapture_acceleration.read/67'
+  GTEST_FILTER_STRING: '-GOTURN.memory_usage:DaSiamRPN.memory_usage:videoio_dynamic.basic_write:videoio/videocapture_acceleration.read/yuv420p_libx265_mp4_FFMPEG_*'
 
 jobs:
   BuildAndTest:

--- a/scripts/test-plan-4.x.json
+++ b/scripts/test-plan-4.x.json
@@ -84,18 +84,10 @@
                 "AsyncAPICancelation/cancel/*"
             ],
             "test_videoio": [
-                "videoio/videoio_synthetic.write_read_position/9",
-                "videoio/videoio_synthetic.write_read_position/12",
-                "videoio/videoio_synthetic.write_read_position/25",
-                "videoio/videoio_synthetic.write_read_position/28",
-                "videoio/videoio_synthetic.write_read_position/10",
-                "videoio/videoio_synthetic.write_read_position/13",
-                "videoio/videoio_synthetic.write_read_position/26",
-                "videoio/videoio_synthetic.write_read_position/29",
-                "videoio/videocapture_acceleration.read/24",
-                "videoio/videocapture_acceleration.read/26",
-                "videoio/videowriter_acceleration.write/40",
-                "videoio/videowriter_acceleration.write/42"
+                "videoio/videoio_synthetic.write_read_position/*_MPEG_GSTREAMER",
+                "videoio/videoio_synthetic.write_read_position/*_MJPG_GSTREAMER",
+                "videoio/videocapture_acceleration.read/yuv420p_mjpeg_mp4_GSTREAMER_*_MAT",
+                "videoio/videowriter_acceleration.write/mkv_MPEG_GSTREAMER_*_MAT"
             ]
         },
         "ubuntu-avx2": {


### PR DESCRIPTION
videoio test filters should be changed due to https://github.com/opencv/opencv/pull/26948 modifying test names