### PR TITLE
Removed MCC test for 5.x branch

### DIFF
--- a/scripts/test-plan-5.x.json
+++ b/scripts/test-plan-5.x.json
@@ -45,7 +45,6 @@
             "opencv_test_img_hash",
             "opencv_test_intensity_transform",
             "opencv_test_line_descriptor",
-            "opencv_test_mcc",
             "opencv_test_ml",
             "opencv_test_optflow",
             "opencv_test_phase_unwrapping",


### PR DESCRIPTION
MCC test (opencv_test_mcc) is removed for opencv 5.x as MCC and CCM are added to objdetect and photo modules respectively in opencv main repo.