### PR TITLE
No need to build entire OpenCV to generate Javadoc.

### DIFF
--- a/.github/workflows/OCV-PR-4.x-docs.yaml
+++ b/.github/workflows/OCV-PR-4.x-docs.yaml
@@ -143,7 +143,7 @@ jobs:
                 -DOPENCV_EXTRA_MODULES_PATH=${{ env.OPENCV_CONTRIB_DOCKER_WORKDIR }}/modules \
                 -DANT_EXECUTABLE=/usr/bin/ant \
                 ${{ env.OPENCV_DOCKER_WORKDIR }}
-          make -j2
+          make opencv_java_jar
           cd modules/java/jar/opencv
           ant javadoc
 

--- a/.github/workflows/OCV-PR-5.x-docs.yaml
+++ b/.github/workflows/OCV-PR-5.x-docs.yaml
@@ -132,7 +132,7 @@ jobs:
         cd ${{ env.OPENCV_CONTRIB_DOCKER_WORKDIR }}
         git bundle create test.bundle ${{ env.LATEST_COMMIT_OPENCV_CONTRIB }}..HEAD || true
         python3 $HOME/scripts/patch_size.py
-        
+
     - name: Generate JavaDoc
       run: |
           mkdir -p ${{ env.OPENCV_BUILD }}
@@ -143,10 +143,10 @@ jobs:
                 -DOPENCV_EXTRA_MODULES_PATH=${{ env.OPENCV_CONTRIB_DOCKER_WORKDIR }}/modules \
                 -DANT_EXECUTABLE=/usr/bin/ant \
                 ${{ env.OPENCV_DOCKER_WORKDIR }}
-          make -j2
+          make opencv_java_jar
           cd modules/java/jar/opencv
           ant javadoc
- 
+
     - name: Build js
       if: ${{ always() && steps.last-repo-step.outcome == 'success' }}
       timeout-minutes: 60

--- a/.github/workflows/build_docs_schedule.yaml
+++ b/.github/workflows/build_docs_schedule.yaml
@@ -65,7 +65,7 @@ jobs:
                 -DOPENCV_EXTRA_MODULES_PATH=${{ env.OPENCV_CONTRIB_DOCKER_WORKDIR }}/modules \
                 -DANT_EXECUTABLE=/usr/bin/ant \
                 ${{ env.OPENCV_DOCKER_WORKDIR }}
-          make -j2
+          make opencv_java_jar
           cd modules/java/jar/opencv
           ant javadoc
           


### PR DESCRIPTION
Optimization. Closes https://github.com/opencv/ci-gha-workflow/issues/251