### PR TITLE
Init git user name and email as GHA virtual machines do no do it.

### DIFF
--- a/checkout-and-merge/action.yaml
+++ b/checkout-and-merge/action.yaml
@@ -37,6 +37,9 @@ runs:
         --single-branch \
         --branch ${{ inputs.target_branch }} \
         https://github.com/opencv/opencv.git
+        cd opencv
+        git config user.email "opencv.ci"
+        git config user.name "opencv.ci"
       echo "::endgroup::"
 
   - if: ${{ github.event.repository.name != 'ci-gha-workflow' && contains(inputs.repos, 'main') && inputs.source_branch }}
@@ -66,6 +69,9 @@ runs:
         --single-branch \
         --branch ${{ inputs.target_branch }} \
         https://github.com/opencv/opencv_contrib.git
+        cd opencv_contrib
+        git config user.email "opencv.ci"
+        git config user.name "opencv.ci"
       echo "::endgroup::"
 
   - if: ${{ github.event.repository.name != 'ci-gha-workflow' && contains(inputs.repos, 'contrib') && inputs.source_branch }}
@@ -95,6 +101,9 @@ runs:
         --single-branch \
         --branch ${{ inputs.target_branch }} \
         https://github.com/opencv/opencv_extra.git
+        cd opencv_extra
+        git config user.email "opencv.ci"
+        git config user.name "opencv.ci"
       echo "::endgroup::"
 
   - if: ${{ github.event.repository.name != 'ci-gha-workflow' && contains(inputs.repos, 'extra') && inputs.source_branch }}


### PR DESCRIPTION
Windows ARM virtual machine:
```
  POST git-upload-pack (491 bytes)
  POST git-upload-pack (976 bytes)
  From https://github.com/asmorkalov/opencv
   * branch                  as/alernative_win_arm_neon_check -> FETCH_HEAD
  Committer identity unknown
  
  *** Please tell me who you are.
  
  Run
  
    git config --global user.email "you@example.com"
    git config --global user.name "Your Name"
  
  to set your account's default identity.
  Omit --global to set the identity only in this repository.
  
  fatal: unable to auto-detect email address (got 'runneradmin@runnervm1u799.(none)')
```
