### PR TITLE
Try use own LAPACK instead of Ubuntu 26.04 BLAS and Lapack.

### DIFF
--- a/.github/workflows/OCV-PR-Linux.yaml
+++ b/.github/workflows/OCV-PR-Linux.yaml
@@ -61,7 +61,7 @@ jobs:
         branch: ${{ fromJSON(needs.branch_eval.outputs.branches )}}
         include:
           - version: '26.04'
-            image: '26.04:20260425'
+            image: '26.04:20260531'
             jpegxl: true
             avif: true
             avx2: true

--- a/docker/ubuntu/Dockerfile-26
+++ b/docker/ubuntu/Dockerfile-26
@@ -65,9 +65,6 @@ RUN \
     libarmadillo-dev \
     libeigen3-dev \
     libsuitesparse-dev \
-    liblapacke-dev \
-    libopenblas-dev \
-    libeigen3-dev \
     libglfw3-dev \
     libceres-dev \
     lcov \


### PR DESCRIPTION
Assumption: They are terrible slow and that`s why calib test is killed by timeout.