### PR TITLE
Increased timeout for calib on Ubuntu 24.04

### DIFF
--- a/run-tests/action.yml
+++ b/run-tests/action.yml
@@ -19,7 +19,7 @@ inputs:
     default: "default"
   timeout:
     description: "One test timeout (min)"
-    default: "15"
+    default: "20"
   options:
     description: "Options in test plan (gtest)"
     default: "default"


### PR DESCRIPTION
OpenBLAS is very slow there by some reason.