### PR TITLE
migrate artifact actions to latest versions

### DIFF
--- a/.github/workflows/OCV-4.x-Android-SDK.yaml
+++ b/.github/workflows/OCV-4.x-Android-SDK.yaml
@@ -120,7 +120,7 @@ jobs:
           zip -r -9 -y python-maven-repo.zip maven_repo
       - name: Release Package
         timeout-minutes: 60
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || env.RUNNER_DEBUG == 1 }}
         with:
           name: OpenCV4AndroidSDK

--- a/.github/workflows/OCV-Contrib-PR-3.4-ARM64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-3.4-ARM64.yaml
@@ -376,7 +376,7 @@ jobs:
       run: cd $HOME/build && xvfb-run -a python3 $HOME/opencv/modules/ts/misc/run.py . -a -t java
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
       with:
         name: junit-html-ubuntu20-arm64

--- a/.github/workflows/OCV-Contrib-PR-3.4-U20.yaml
+++ b/.github/workflows/OCV-Contrib-PR-3.4-U20.yaml
@@ -376,7 +376,7 @@ jobs:
       run: cd $HOME/build && xvfb-run -a python3 $HOME/opencv/modules/ts/misc/run.py . -a -t java
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
       with:
         name: junit-html-ubuntu20-x86-64

--- a/.github/workflows/OCV-Contrib-PR-3.4-W10.yaml
+++ b/.github/workflows/OCV-Contrib-PR-3.4-W10.yaml
@@ -369,7 +369,7 @@ jobs:
         ${{ github.workspace }}\opencv\modules\ts\misc\run.py . -a -t java
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
       with:
         name: junit-html-windows10

--- a/.github/workflows/OCV-Contrib-PR-3.4-macOS-ARM64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-3.4-macOS-ARM64.yaml
@@ -427,7 +427,7 @@ jobs:
       working-directory: ${{ github.workspace }}/build
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
       with:
         name: junit-html-macos-arm64

--- a/.github/workflows/OCV-Contrib-PR-3.4-macOS-x86_64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-3.4-macOS-x86_64.yaml
@@ -427,7 +427,7 @@ jobs:
       working-directory: ${{ github.workspace }}/build
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
       with:
         name: junit-html-macos-x86-64

--- a/.github/workflows/OCV-Contrib-PR-4.x-ARM64-FastCV.yaml
+++ b/.github/workflows/OCV-Contrib-PR-4.x-ARM64-FastCV.yaml
@@ -438,7 +438,7 @@ jobs:
       run: cd $HOME/build && xvfb-run -a python3 $HOME/opencv/modules/ts/misc/run.py . -a -t java
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
       with:
         name: junit-html-ubuntu20-arm64-fastcv

--- a/.github/workflows/OCV-Contrib-PR-4.x-ARM64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-4.x-ARM64.yaml
@@ -430,7 +430,7 @@ jobs:
       run: cd $HOME/build && xvfb-run -a python3 $HOME/opencv/modules/ts/misc/run.py . -a -t java
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
       with:
         name: junit-html-ubuntu20-arm64

--- a/.github/workflows/OCV-Contrib-PR-4.x-W10.yaml
+++ b/.github/workflows/OCV-Contrib-PR-4.x-W10.yaml
@@ -416,7 +416,7 @@ jobs:
         ${{ github.workspace }}\opencv\modules\ts\misc\run.py . -a -t java
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
       with:
         name: junit-html-windows10

--- a/.github/workflows/OCV-Contrib-PR-4.x-macOS-ARM64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-4.x-macOS-ARM64.yaml
@@ -490,7 +490,7 @@ jobs:
       working-directory: ${{ github.workspace }}/build
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
       with:
         name: junit-html-macos-arm64

--- a/.github/workflows/OCV-Contrib-PR-4.x-macOS-x86_64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-4.x-macOS-x86_64.yaml
@@ -491,7 +491,7 @@ jobs:
       working-directory: ${{ github.workspace }}/build
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
       with:
         name: junit-html-macos-x86-64

--- a/.github/workflows/OCV-Contrib-PR-5.x-ARM64-FastCV.yaml
+++ b/.github/workflows/OCV-Contrib-PR-5.x-ARM64-FastCV.yaml
@@ -444,7 +444,7 @@ jobs:
       run: cd $HOME/build && xvfb-run -a python3 $HOME/opencv/modules/ts/misc/run.py . -a -t java
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
       with:
         name: junit-html-ubuntu20-arm64-fastcv

--- a/.github/workflows/OCV-Contrib-PR-5.x-ARM64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-5.x-ARM64.yaml
@@ -436,7 +436,7 @@ jobs:
       run: cd $HOME/build && xvfb-run -a python3 $HOME/opencv/modules/ts/misc/run.py . -a -t java
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
       with:
         name: junit-html-ubuntu20-arm64

--- a/.github/workflows/OCV-Contrib-PR-5.x-W10.yaml
+++ b/.github/workflows/OCV-Contrib-PR-5.x-W10.yaml
@@ -429,7 +429,7 @@ jobs:
         ${{ github.workspace }}\opencv\modules\ts\misc\run.py . -a -t java
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
       with:
         name: junit-html-windows10

--- a/.github/workflows/OCV-Contrib-PR-5.x-macOS-ARM64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-5.x-macOS-ARM64.yaml
@@ -492,7 +492,7 @@ jobs:
       working-directory: ${{ github.workspace }}/build
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
       with:
         name: junit-html-macos-arm64

--- a/.github/workflows/OCV-Contrib-PR-5.x-macOS-x86_64.yaml
+++ b/.github/workflows/OCV-Contrib-PR-5.x-macOS-x86_64.yaml
@@ -505,7 +505,7 @@ jobs:
       working-directory: ${{ github.workspace }}/build
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv-contrib.outcome == 'success' }}
       with:
         name: junit-html-macos-x86-64

--- a/.github/workflows/OCV-Contrib-WinPack-4.x-W10.yaml
+++ b/.github/workflows/OCV-Contrib-WinPack-4.x-W10.yaml
@@ -200,7 +200,7 @@ jobs:
         %CI_SCRIPTS%\winpack_create.cmd
     - name: Save WinPack
       timeout-minutes: 60
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: WinPack
         path: artifacts\distrib.7z.exe
@@ -221,7 +221,7 @@ jobs:
       run: cd ${{ github.workspace }} && rm -rf *
     - name: Download WinPack
       timeout-minutes: 60
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v8
       with:
         name: WinPack
     - name: Unzip WinPack

--- a/.github/workflows/OCV-Coverage-4.x-U20.yaml
+++ b/.github/workflows/OCV-Coverage-4.x-U20.yaml
@@ -179,7 +179,7 @@ jobs:
       run: cd /home/ci/build && xvfb-run -a python3 ${{ env.OPENCV_DOCKER_WORKDIR }}/modules/ts/misc/run.py . -a -t java --test_threads=2 --test_tag_skip=size_hd
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
       with:
         name: junit-html
@@ -205,7 +205,7 @@ jobs:
         genhtml --prefix /home/ci -t "OpenCV: ${{ env.TARGET_BRANCH_NAME }}-$GITHUB_SHA" -o /home/ci/build/test_coverage_html /home/ci/build/opencv_test_filtered.info
     - name: Upload test coverage
       timeout-minutes: 60
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: ${{ always() && steps.coverage-test-report.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
       with:
         name: test-coverage-html
@@ -291,7 +291,7 @@ jobs:
         genhtml --prefix /home/ci -t "OpenCV: ${{ env.TARGET_BRANCH_NAME }}-$GITHUB_SHA" -o /home/ci/build/perf_coverage_html /home/ci/build/opencv_perf_filtered.info
     - name: Upload perf coverage
       timeout-minutes: 60
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: ${{ always() && steps.coverage-perf-report.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
       with:
         name: perf-coverage-html

--- a/.github/workflows/OCV-PR-3.4-ARM64.yaml
+++ b/.github/workflows/OCV-PR-3.4-ARM64.yaml
@@ -243,7 +243,7 @@ jobs:
       run: cd $HOME/build && xvfb-run -a python3 ${{ env.OPENCV_DOCKER_WORKDIR }}/modules/ts/misc/run.py . -a -t java
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
       with:
         name: junit-html-ubuntu20-arm64

--- a/.github/workflows/OCV-PR-3.4-Android.yaml
+++ b/.github/workflows/OCV-PR-3.4-Android.yaml
@@ -89,7 +89,7 @@ jobs:
         run: cd /home/ci/build && zip -r -9 -y OpenCV3Android.zip OpenCV-android-sdk
       - name: Release Package
         timeout-minutes: 60
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || env.RUNNER_DEBUG == 1 }}
         with:
           name: OpenCV3AndroidSDK

--- a/.github/workflows/OCV-PR-3.4-U20.yaml
+++ b/.github/workflows/OCV-PR-3.4-U20.yaml
@@ -244,7 +244,7 @@ jobs:
       run: cd $HOME/build && xvfb-run -a python3 ${{ env.OPENCV_DOCKER_WORKDIR }}/modules/ts/misc/run.py . -a -t java
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
       with:
         name: junit-html-ubuntu20-x86-64

--- a/.github/workflows/OCV-PR-3.4-W10.yaml
+++ b/.github/workflows/OCV-PR-3.4-W10.yaml
@@ -245,7 +245,7 @@ jobs:
         ${{ github.workspace }}\opencv\modules\ts\misc\run.py . -a -t java
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
       with:
         name: junit-html-windows10

--- a/.github/workflows/OCV-PR-3.4-iOS.yaml
+++ b/.github/workflows/OCV-PR-3.4-iOS.yaml
@@ -61,7 +61,7 @@ jobs:
         run: cd ${{ github.workspace }}/ios && zip -r -9 -y opencv-3.4-ios-framework.zip opencv2.framework
       - name: Upload Artifact
         timeout-minutes: 60
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || env.RUNNER_DEBUG == 1 }}
         with:
           name: OpenCViOSFramework

--- a/.github/workflows/OCV-PR-3.4-macOS-ARM64.yaml
+++ b/.github/workflows/OCV-PR-3.4-macOS-ARM64.yaml
@@ -265,7 +265,7 @@ jobs:
       working-directory: ${{ github.workspace }}/build
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
       with:
         name: junit-html-macos-arm64

--- a/.github/workflows/OCV-PR-3.4-macOS-x86_64.yaml
+++ b/.github/workflows/OCV-PR-3.4-macOS-x86_64.yaml
@@ -265,7 +265,7 @@ jobs:
       working-directory: ${{ github.workspace }}/build
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
       with:
         name: junit-html-macos-x86-64

--- a/.github/workflows/OCV-PR-4.x-ARM64-Debug.yaml
+++ b/.github/workflows/OCV-PR-4.x-ARM64-Debug.yaml
@@ -194,7 +194,7 @@ jobs:
       run: cd $HOME/build && xvfb-run -a python3 ${{ env.OPENCV_DOCKER_WORKDIR }}/modules/ts/misc/run.py . -a -t java
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
       with:
         name: junit-html-ubuntu20-arm64-debug

--- a/.github/workflows/OCV-PR-4.x-ARM64.yaml
+++ b/.github/workflows/OCV-PR-4.x-ARM64.yaml
@@ -242,7 +242,7 @@ jobs:
       run: cd $HOME/build && xvfb-run -a python3 ${{ env.OPENCV_DOCKER_WORKDIR }}/modules/ts/misc/run.py . -a -t java
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
       with:
         name: junit-html-ubuntu20-arm64

--- a/.github/workflows/OCV-PR-4.x-Android-Test.yaml
+++ b/.github/workflows/OCV-PR-4.x-Android-Test.yaml
@@ -116,7 +116,7 @@ jobs:
     - name: Save Unit Test Results
       timeout-minutes: 5
       if: 0 # ${{ always() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: android-junit-html
         path: |

--- a/.github/workflows/OCV-PR-4.x-W10-Vulkan.yaml
+++ b/.github/workflows/OCV-PR-4.x-W10-Vulkan.yaml
@@ -125,7 +125,7 @@ jobs:
     #   run: cd ${{ github.workspace }}\build && bin\opencv_perf_dnn.exe --perf_impl=plain --perf_min_samples=1 --perf_force_samples=1 --perf_verify_sanity --skip_unstable=1 --gtest_filter=${{ env.GTEST_FILTER_STRING }} --perf_threads=%PARALLEL_JOBS%
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
       with:
         name: junit-html-windows10-vulkan

--- a/.github/workflows/OCV-PR-4.x-W10.yaml
+++ b/.github/workflows/OCV-PR-4.x-W10.yaml
@@ -243,7 +243,7 @@ jobs:
         ${{ github.workspace }}\opencv\modules\ts\misc\run.py . -a -t java
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
       with:
         name: junit-html-windows10

--- a/.github/workflows/OCV-PR-4.x-iOS.yaml
+++ b/.github/workflows/OCV-PR-4.x-iOS.yaml
@@ -61,7 +61,7 @@ jobs:
         run: cd ${{ github.workspace }}/ios && zip -r -9 -y opencv-4.x-ios-framework.zip opencv2.framework
       - name: Upload Artifact
         timeout-minutes: 60
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || env.RUNNER_DEBUG == 1 }}
         with:
           name: OpenCViOSFramework

--- a/.github/workflows/OCV-PR-4.x-loongnix-loongarch64.yaml
+++ b/.github/workflows/OCV-PR-4.x-loongnix-loongarch64.yaml
@@ -259,7 +259,7 @@ jobs:
         working-directory: ${{ github.workspace }}/build
       - name: Save Unit Test Results
         timeout-minutes: 60
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' && steps.check-warnings.outcome == 'success' }}
         with:
           name: junit-html-loongarch

--- a/.github/workflows/OCV-PR-4.x-macOS-ARM64-Vulkan.yaml
+++ b/.github/workflows/OCV-PR-4.x-macOS-ARM64-Vulkan.yaml
@@ -125,7 +125,7 @@ jobs:
       working-directory: ${{ github.workspace }}/build
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
       with:
         name: junit-html-macos-arm64-vulkan

--- a/.github/workflows/OCV-PR-4.x-macOS-ARM64.yaml
+++ b/.github/workflows/OCV-PR-4.x-macOS-ARM64.yaml
@@ -261,7 +261,7 @@ jobs:
       working-directory: ${{ github.workspace }}/build
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
       with:
         name: junit-html-macos-arm64

--- a/.github/workflows/OCV-PR-4.x-macOS-x86_64.yaml
+++ b/.github/workflows/OCV-PR-4.x-macOS-x86_64.yaml
@@ -262,7 +262,7 @@ jobs:
       working-directory: ${{ github.workspace }}/build
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
       with:
         name: junit-html-macos-x86-64

--- a/.github/workflows/OCV-PR-5.x-ARM64-Debug.yaml
+++ b/.github/workflows/OCV-PR-5.x-ARM64-Debug.yaml
@@ -200,7 +200,7 @@ jobs:
       run: cd $HOME/build && xvfb-run -a python3 ${{ env.OPENCV_DOCKER_WORKDIR }}/modules/ts/misc/run.py . -a -t java
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
       with:
         name: junit-html-ubuntu20-arm64-debug

--- a/.github/workflows/OCV-PR-5.x-ARM64.yaml
+++ b/.github/workflows/OCV-PR-5.x-ARM64.yaml
@@ -266,7 +266,7 @@ jobs:
       run: cd $HOME/build && xvfb-run -a python3 ${{ env.OPENCV_DOCKER_WORKDIR }}/modules/ts/misc/run.py . -a -t java
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
       with:
         name: junit-html-ubuntu20-arm64

--- a/.github/workflows/OCV-PR-5.x-Android.yaml
+++ b/.github/workflows/OCV-PR-5.x-Android.yaml
@@ -126,7 +126,7 @@ jobs:
           zip -r -9 -y python-maven-repo.zip maven_repo
       - name: Release Package
         timeout-minutes: 60
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || env.RUNNER_DEBUG == 1 }}
         with:
           name: OpenCV4AndroidSDK

--- a/.github/workflows/OCV-PR-5.x-W10.yaml
+++ b/.github/workflows/OCV-PR-5.x-W10.yaml
@@ -250,7 +250,7 @@ jobs:
         ${{ github.workspace }}\opencv\modules\ts\misc\run.py . -a -t java
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
       with:
         name: junit-html-windows10

--- a/.github/workflows/OCV-PR-5.x-iOS.yaml
+++ b/.github/workflows/OCV-PR-5.x-iOS.yaml
@@ -61,7 +61,7 @@ jobs:
         run: cd ${{ github.workspace }}/ios && zip -r -9 -y opencv-5.x-ios-framework.zip opencv2.framework
       - name: Upload Artifact
         timeout-minutes: 60
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || env.RUNNER_DEBUG == 1 }}
         with:
           name: OpenCViOSFramework

--- a/.github/workflows/OCV-PR-5.x-macOS-ARM64.yaml
+++ b/.github/workflows/OCV-PR-5.x-macOS-ARM64.yaml
@@ -276,7 +276,7 @@ jobs:
       working-directory: ${{ github.workspace }}/build
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
       with:
         name: junit-html-macos-arm64

--- a/.github/workflows/OCV-PR-5.x-macOS-x86_64.yaml
+++ b/.github/workflows/OCV-PR-5.x-macOS-x86_64.yaml
@@ -277,7 +277,7 @@ jobs:
       working-directory: ${{ github.workspace }}/build
     - name: Save Unit Test Results
       timeout-minutes: 60
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: ${{ always() && steps.java-test.outcome == 'success' && steps.build-opencv.outcome == 'success' }}
       with:
         name: junit-html-macos-x86-64

--- a/.github/workflows/OCV-WinPack-4.x-W10.yaml
+++ b/.github/workflows/OCV-WinPack-4.x-W10.yaml
@@ -224,7 +224,7 @@ jobs:
         %CI_SCRIPTS%\winpack_create.cmd
     - name: Save WinPack
       timeout-minutes: 60
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: WinPack
         path: artifacts\distrib.7z.exe
@@ -245,7 +245,7 @@ jobs:
       run: cd ${{ github.workspace }} && rm -rf *
     - name: Download WinPack
       timeout-minutes: 60
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: WinPack
     - name: Unzip WinPack

--- a/.github/workflows/OCV-WinPack-5.x-W10.yaml
+++ b/.github/workflows/OCV-WinPack-5.x-W10.yaml
@@ -224,7 +224,7 @@ jobs:
         %CI_SCRIPTS%\winpack_create.cmd
     - name: Save WinPack
       timeout-minutes: 60
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: WinPack
         path: artifacts\distrib.7z.exe
@@ -245,7 +245,7 @@ jobs:
       run: cd ${{ github.workspace }} && rm -rf *
     - name: Download WinPack
       timeout-minutes: 60
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: WinPack
     - name: Unzip WinPack

--- a/.github/workflows/build_docs_schedule.yaml
+++ b/.github/workflows/build_docs_schedule.yaml
@@ -93,7 +93,7 @@ jobs:
         run: cmake --build . --config release --target doxygen -- -j$(nproc) 2>&1 | tee log.txt
 
       - name: Archive Doxygen Docs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: opencv-docs-${{ matrix.branch }}
           path: |


### PR DESCRIPTION
Node.js 20 has reached [end-of-life on April 30, 2026](https://github.com/nodejs/release#readme).
Old Github Actions steps use old Node.js 20 and have to be updated.
Related Github Actions changes: https://github.com/actions/runner-images/issues/14029